### PR TITLE
Dev environment and contributing guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+# emacs backup files
+*~
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ ds = rt.Dataset(df)
 ```
 How can I contribute?
 ---------------------
-RipTable has been public open sourced because it needs more users and contributions to take it to the next level.  The RipTable team is confident the engine is the next generation building block for python data analytics computing.  We need help from reporting bugs, docs, improved functionality, and new functionality.  Please consider a github pull request or email the team.
+RipTable has been public open sourced because it needs more users and
+contributions to take it to the next level.  The RipTable team is confident
+the engine is the next generation building block for python data analytics
+computing.  We need help from reporting bugs, docs, improved functionality,
+and new functionality.  Please consider a github pull request or email the
+team.
+
+See the [contributing guide](docs/CONTRIBUTING.md) for more information.
 
 How can I trust RipTable calculations?
 --------------------------------------

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+How can I contribute?
+---------------------
+
+New developers should set up a dedicated environment for working with
+`riptable`. To do so, first
+[create an environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
+from the environment file:
+```bash
+conda env create -f environment.yml
+```
+
+**Note**: some users have had trouble completing the installation of the
+`riptide_cpp` requirement on Mac machines due to a dependence on
+[`zstd`](https://github.com/facebook/zstd). A temporary work around is to use
+Homebrew to install `zstd` ahead of time
+```bash
+brew install zstd
+```
+See the [open issue](https://github.com/rtosholdings/riptable/issues/6) on the
+topic for more information.
+
+One the environment is created, activate it
+```bash
+conda activate rtdev
+```
+and finally install `riptable`
+```bash
+python setup.py install
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: rtdev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.7
+  - numpy
+  - scipy
+  - numba
+  - python-dateutil
+  - pandas
+  - pre-commit
+  - black
+  - flake8
+  - pytest
+  - coverage


### PR DESCRIPTION
This PR:
- adds an `environment.yml` file to setup the `rtdev` environment that is meant for developers to work in
- creates `CONTRIBUTING.md` and links to it from the `README.md`

This should be merged after #7, since I accidentally made that PR from my `master` branch, and the changes between #7 and this PR overlap. I will not do this in the future.