### PR TITLE
Use setuptools_scm for versioning

### DIFF
--- a/.github/workflows/conda_package.yaml
+++ b/.github/workflows/conda_package.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Miniconda
         uses: goanpeca/setup-miniconda@v1
         with:
@@ -26,8 +28,9 @@ jobs:
         shell: bash -l {0}
         run: |
           set -ex
-          conda create -n conda_build python=3.8 conda-build anaconda-client -y
+          conda create -n conda_build python=3.8 conda-build anaconda-client setuptools_scm -y
           conda activate conda_build
+          export BUILD_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='post-release'))")
           mkdir conda_pkgs_output
           conda build conda_recipe -c ${ANACONDA_USER} --output-folder ./conda_pkgs_output
           echo "${{ github.event_name }}"

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: riptable
-  version: "{{ load_file_regex(load_file='../riptable/_version.py', regex_pattern='\d+\.\d+\.\d+([ab]\d+|)', from_recipe_dir=True).group() }}"
+  version: "{{ environ.get('BUILD_VERSION', 'DEV') }}"
 
 build:
   number: 0
@@ -12,6 +12,7 @@ requirements:
   build:
     - python {{ python }}
     # The following requirements are in the build because setup.py requires them.
+    - setuptools_scm
     - riptide_cpp >=1.6,<1.7
     - ansi2html >=1.5.2
     - numba >=0.44
@@ -44,6 +45,7 @@ test:
 
 about:
   home: https://github.com/rtosholdings/riptable
+  license: BSD 3-Clause+Patent License
   license_file:
     - LICENSE
     - LICENSES-thirdparty.md

--- a/riptable/_version.py
+++ b/riptable/_version.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.11'
+__version__ = 'DEV'

--- a/setup.py
+++ b/setup.py
@@ -9,16 +9,17 @@ import logging
 import re
 
 package_name='riptable'
-# N.B. Need to read the file and use regex to get the version number because I can't import riptable
-#      here before pip has chance to know the dependencies and install them.
-with open('riptable/_version.py', 'r') as f:
-    version = re.search('\d+\.\d+\.\d+([ab]\d+|)', f.readline()).group()
 
 setup(
     name = package_name,
     packages = [package_name],
+    use_scm_version = {
+        'version_scheme': 'post-release',
+        'write_to': 'riptable/_version.py',
+        'write_to_template': '__version__ = "{version}"',
+    },
+    setup_requires=['setuptools_scm'],
     package_dir = {package_name: 'riptable'},
-    version = version,
     description = 'Python Package for riptable studies framework',
     author = 'RTOS Holdings',
     author_email = 'thomasdimitri@gmail.com',


### PR DESCRIPTION
FYI, the file `_version.py` will be written by setuptools_scm in build time when `python setup.py` runs.

Please make a up-to-date tag for the latest version (1.0.9). The current tag is only 1.0.3. The commits that changed `_version.py` look like good places to put the tags.

Thanks.