### PR TITLE
Some PEP 484 type annotations for Categories

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -224,6 +224,8 @@ class Categories:
     default_colname = "key_0"
     multikey_spacer = " "
 
+    _grouping: Grouping
+
     list_modes    = [ CategoryMode.StringArray, CategoryMode.NumericArray ]
     dict_modes    = [ CategoryMode.IntEnum, CategoryMode.Dictionary ]
     string_modes  = [ CategoryMode.StringArray, CategoryMode.IntEnum, CategoryMode.Dictionary ]
@@ -317,7 +319,7 @@ class Categories:
 
     # ------------------------------------------------------------------------------
     @classmethod
-    def from_grouping(cls, grouping, invalid_category=None):
+    def from_grouping(cls, grouping: Grouping, invalid_category=None):
         ordered = grouping.isordered
         # grouping has already flipped bytes to unicode, or kept unicode
         unicode = True


### PR DESCRIPTION
I've added a couple of PEP 484 type annotations for the ``Categories`` class. These specific annotations are being added because they make a big difference in being able to infer the correct types for attributes/properties (and some return values of properties) within both ``Categories`` and ``Categorical``.