### PR TITLE
Documentation upgrade

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,18 @@ release = '1.0.5'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.napoleon']
+extensions = [
+    "autoapi.extension",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx_rtd_theme",
+    'sphinx.ext.napoleon',
+]
 
 # Napoleon settings
 napoleon_google_docstring = True
@@ -69,3 +80,7 @@ html_static_path = ['_static']
 
 # TJD -- needed or sphinx fails near final stages
 master_doc = 'index'
+
+# Autoapi settings
+
+autoapi_dirs = ["../../riptable"]


### PR DESCRIPTION
The [current documentation](https://riptable.readthedocs.io/en/latest/py-modindex.html) is not ideal because all submodules of riptable are compiled onto a single page. As an example [here is the page for `rt_dataset`](https://riptable.readthedocs.io/en/latest/riptable.html#module-riptable.rt_dataset). For me, it takes a few seconds for the entire page to load and then navigate to the correct submodule.

This PR upgrades the docs by breaking the submodules onto different pages using the `sphinx-autoapi` package.

Specifically, this PR:
- adds some extensions to `conf.py` that are objectively useful (e.g. todo notes)
- adds an `autoapi` settings line at the end that points to the source directory
- commits the `docs/source/_static` directory that should have been committed from the start. The reason this needs to exist is that building the docs locally is impossible without it existing, since it is specified in the `conf.py` file (in other words, the `conf.py` on `master` is not locally runnable at the moment)

Here is a screenshot of the new landing page:
<img width="1169" alt="Screen Shot 2020-12-22 at 10 48 48 AM" src="https://user-images.githubusercontent.com/10226392/102923181-2a1de800-4444-11eb-921b-3d402580decd.png">


And here is a screenshot of what you get when you click "rt_dataset" from the "Module Index" page:
<img width="1172" alt="Screen Shot 2020-12-22 at 10 49 05 AM" src="https://user-images.githubusercontent.com/10226392/102923259-4cb00100-4444-11eb-8fc5-1c79debe1bd5.png">

Note that only the `rt_dataset` submodule is on the page, letting it load faster and make for a more enjoyable documentation experience.
