### PR TITLE
Prefer conda-forge channel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # the mac computer used by github actions is too old to run the tests
-        # when fixed, add back macos-latest.  notee: mac user can still download and use riptable
+        # when fixed, add back macos-latest.  note: mac user can still download and use riptable
         os: [ubuntu-latest, windows-latest]
         # 3.9 does not work because of llvmlite, 3.6 fails for another reason
         python-version: [3.7, 3.8]
@@ -93,11 +93,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2.0.1
         env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:
           activate-environment: ""
+          auto-update-conda: true
+          channels: conda-forge
+          channel-priority: flexible
+          show-channel-urls: true
       - name: Build Package
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Migrate to the latest version of the ``setup-miniconda`` GH action. Prefer the conda-forge channel over the default channel in conda builds, as conda-forge is typically more up-to-date.