### PR TITLE
Merge categorical fix

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -889,7 +889,7 @@ class Categories:
         return newcat
 
     # ------------------------------------------------------------
-    def categories_as_dict(self):
+    def categories_as_dict(self) -> Mapping[str, FastArray]:
         """
         Groupby keys can be prepared for the calling Categorical.
         """

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -539,7 +539,8 @@ class FastArray(np.ndarray):
 
         Returns
         -------
-        The array name or if the name does not exist, None is retuned.
+        str, optional
+            The array name; or None if the array has not been named.
 
         See Also
         --------
@@ -563,7 +564,8 @@ class FastArray(np.ndarray):
 
         Returns
         -------
-        FastArray (or subclass)
+        FastArray
+            Returns 'self', so this will be the same type as the instance it's called on.
 
         Examples
         --------

--- a/riptable/rt_groupbyops.py
+++ b/riptable/rt_groupbyops.py
@@ -1,10 +1,18 @@
 __all__ = ['GroupByOps']
+#import abc
+from typing import TYPE_CHECKING, Optional
 import warnings
+
 import numpy as np
 import riptide_cpp as rc
+
 from .rt_enum import GB_FUNCTIONS, GB_STRING_ALLOWED, GB_FUNC_COUNT, GB_PACKUNPACK, TypeRegister, ApplyType
+from .rt_grouping import Grouping
 from .rt_numpy import zeros_like, bool_to_fancy, empty_like, groupbyhash
-from .rt_timers import tt
+
+if TYPE_CHECKING:
+    from .rt_dataset import Dataset
+
 
 #=====================================================================================================
 #=====================================================================================================
@@ -46,6 +54,13 @@ class GroupByOps(object):
         'amin' : 'min',
         'amax' : 'max',
     }
+
+    # TODO: Consider making GroupByOps an abc, and defining .grouping as a property;
+    #       that'll be a bit cleaner and more robust than using a type annotation here
+    #       to indicate the derived classes are expected to have a property/attribute
+    #       with that name (per the docstring for GroupByOps).
+    #       Maybe also include 'gb_keychain' and '_dataset', they're both used within this class.
+    grouping: Grouping
 
 
     def __init__(self):
@@ -126,7 +141,7 @@ class GroupByOps(object):
         return self._iter_internal()
 
     #---------------------------------------------------------------
-    def _iter_internal(self, dataset=None):
+    def _iter_internal(self, dataset: Optional['Dataset'] = None):
         '''
         Generates pairs of labels and the stored dataset sliced by their fancy indices.
         Right now, this is only called by categorical. Groupby has a faster way of return dataset slices.
@@ -179,7 +194,7 @@ class GroupByOps(object):
             yield self.key_from_bin(i), cds
 
     #---------------------------------------------------------------
-    def get_groupings(self, filter=None):
+    def get_groupings(self, filter: Optional[np.ndarray] = None):
         '''
         Parameters
         ----------

--- a/riptable/rt_merge.py
+++ b/riptable/rt_merge.py
@@ -2303,6 +2303,14 @@ def merge2(
     # an input column will contain the same data in the output Dataset.
     array_copier = array_copy if copy else readonly_array_wrapper
 
+    # Workaround for rt.mbget not supporting Categoricals (so it ends up using the regular
+    # integer invalids in the underlying array vs. the Categorical base index).
+    # We still do want to use mbget() when possible since we need it to support the case where
+    # we're trying to index into an np.ndarray, and eventually we want to use it to allow the
+    # caller to provide their own per-column overrides for default values.
+    def mbget_wrapper(arr: np.ndarray, index: np.ndarray, default_value = None) -> np.ndarray:
+        return mbget(arr, index, default_value) if type(arr) in (FastArray, np.ndarray) else arr[index]
+
     # Begin creating the column data for the 'merged' Dataset.
     out: Dict[str, FastArray] = {}
     start = GetNanoTime()
@@ -2328,8 +2336,8 @@ def merge2(
                 #   the output type but we compute the output length from the fancy indices; then, when copying to the
                 #   result, we use the fancy indices to pull from the source arrays rather than a straight 1-to-1 copy.
                 #   This function would allow for a few array allocations + operations to be elided here.
-                left_data = left[field] if left_fancyindex is None else mbget(left[field], left_fancyindex[:len(left_fancyindex) - join_indices.right_only_rowcount])
-                right_data = mbget(right[field], right_fancyindex[-join_indices.right_only_rowcount:])
+                left_data = left[field] if left_fancyindex is None else mbget_wrapper(left[field], left_fancyindex[:len(left_fancyindex) - join_indices.right_only_rowcount])
+                right_data = mbget_wrapper(right[field], right_fancyindex[-join_indices.right_only_rowcount:])
                 out[field] = hstack((left_data, right_data))
 
         # If we're missing one of the fancy indices, it means we can just copy the columns
@@ -2352,7 +2360,7 @@ def merge2(
             #      from the right Dataset instead.
             ds, fancyindex = (right, right_fancyindex) if how == 'right' else (left, left_fancyindex)
             for field in intersection_cols:
-                out[field] = mbget(ds[field], fancyindex)
+                out[field] = mbget_wrapper(ds[field], fancyindex)
 
     if logger.isEnabledFor(logging.INFO):
         delta = GetNanoTime() - start
@@ -2371,7 +2379,7 @@ def merge2(
             out[new_name] = array_copier(left[old_name])
     else:
         for old_name, new_name in zip(*col_left_tuple):
-            out[new_name] = mbget(left[old_name], left_fancyindex)
+            out[new_name] = mbget_wrapper(left[old_name], left_fancyindex)
 
     if logger.isEnabledFor(logging.INFO):
         delta = GetNanoTime() - start
@@ -2402,7 +2410,7 @@ def merge2(
                 raise ValueError('One or more keys from the left Dataset was missing from the right Dataset.')
 
         for old_name, new_name in zip(*col_right_tuple):
-            out[new_name] = mbget(right[old_name], right_fancyindex)
+            out[new_name] = mbget_wrapper(right[old_name], right_fancyindex)
 
     if logger.isEnabledFor(logging.INFO):
         delta = GetNanoTime() - start

--- a/riptable/tests/test_merge.py
+++ b/riptable/tests/test_merge.py
@@ -1845,6 +1845,14 @@ def test_merge2_multikey_join_with_cats():
     result = rt.merge2(left_ds, right_ds, on=['InkColor', ('CartridgeInstallDate', 'PurchaseDate')], suffixes=('_installed', '_purchased'))
     assert len(result) == 8
 
+    # The Categorical columns in the resulting Dataset should not have any
+    # negative values in the underlying array. This is to check for an issue
+    # introduced in 44585e527e where mbget() started being used, but it used the
+    # normal default value for the Categorical's underlying array instead of the
+    # Categorical's base index (if it has one).
+    assert np.all(result['InkColor']._fa >= 0)
+    assert np.all(result['PurchaseDate']._fa >= 0)
+
 
 def test_merge2_nonempty_symmetric_diff():
     ds1 = rt.Dataset({'a': [1, 2, 3]})


### PR DESCRIPTION
This fixes a bug introduced to ``rt.merge2()`` / ``rt.merge_lookup()`` in 44585e527e, which occurs because ``rt.mbget()`` does not recognize that ``Categorical`` instances need special handling. The earlier change was made because users can occasionally end up with instances of ``np.ndarray`` in their Datasets (though how this happens is unclear to me; such arrays should always be wrapped in a ``FastArray`` view); the workaround here is to special-case ``np.ndarray`` and ``rt.FastArray`` to go through ``rt.mbget()`` but for other types (at least for now) we'll use the indexer syntax so whichever array type we get can decide how to handle the invalid/sentinel values in the fancy index.