### PR TITLE
Update rt_categorical.py for empty set

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -3105,6 +3105,8 @@ class Categorical(GroupByOps, FastArray):
         if isinstance(x, (list, np.ndarray)):
             if len(x) > 1:
                 return ismember(self, x)[0]
+            elif len(x) <=0:
+                return ismember(self, x)[0]
             elif np.isscalar(x[0]):
                 return self == x[0]
         return self == x


### PR DESCRIPTION
I'm guessing that if someone asks if something is a category, and gives an empty array the answer is FALSE;
Passes runtests
If this is not the correct behavior let me know.