### PR TITLE
Update rt_categorical.py

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -3105,8 +3105,8 @@ class Categorical(GroupByOps, FastArray):
         if isinstance(x, (list, np.ndarray)):
             if len(x) > 1:
                 return ismember(self, x)[0]
-            elif np.isscalar(x[0]):
-                return self == x[0]
+            elif np.isscalar(x):
+                return self == x
         return self == x
 
     # -------------------------------------------------------


### PR DESCRIPTION
Handles passing empty list by actually checking if there is one element; 
>>>>rt.Cat([1]).isin([]) 
_categorical_compare_check raise ValueError("List was empty.")
>>> rt.Cat([1]).isin([1])
FastArray([ True])
>>> rt.Cat([1]).isin([2])
FastArray([False])
>>> rt.Cat([1]).isin([1,2])
FastArray([ True])