### PR TITLE
Relax pandas version constraint upper-bound

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('riptide_cpp', min_pin='x.x', max_pin='x.x') }}
-    - pandas >=0.24,<1.1
+    - pandas >=0.24,<2.0
     - ansi2html >=1.5.2
     - numba >=0.44
     - python-dateutil


### PR DESCRIPTION
Users have reported riptable works as expected when interoperating with newer versions of pandas (e.g. 1.1.x, 1.2.x). It seems like we should be able to relax the upper-bound constraint. It'd be good to follow-up by adding a tox configuration to run the unit tests against several of the minor point-release versions of pandas to make sure the riptable <-> pandas interop code works across multiple versions of pandas, e.g. ``0.24``, ``1.0``, ``1.1``, ``1.2``.

This would address #121.