### PR TITLE
Don't suppress errors in hstack() implementations for derived array types

### DIFF
--- a/riptable/tests/test_rtnumpy.py
+++ b/riptable/tests/test_rtnumpy.py
@@ -215,6 +215,25 @@ class TestRTNumpy:
         fa_sample_expected = rt.FA([2, 5])
         assert (fa_sample_expected == fa_sample).all(axis=None)
 
+    def test_hstack_returns_same_type(self):
+        # Create some instances of the same derived array type.
+        # TODO: Implement another version of this test using a derived array type (maybe define one just for this test)
+        #       that does not define it's own 'hstack' method. Or, test what happens if we e.g. hstack something like
+        #       rt.Date() and a list (that could be used to create an array of that type).
+        array_type = rt.Date
+
+        arrs = [
+            array_type(['20210108', '20210108', '20210115', '20210115', '20210115', '20210122', '20210129', '20210129']),
+            array_type(['20200102']),
+            array_type(['20190103', '20190204', '20190305'])
+        ]
+        total_len = sum(map(lambda x: len(x), arrs))
+
+        # rt.hstack() should return an instance of the same type.
+        result = rt.hstack(arrs)
+        assert type(result) == array_type
+        assert len(result) == total_len
+
 
 class TestMaximum:
     """Tests for the rt.maximum function."""


### PR DESCRIPTION
``rt.hstack()`` has a bug -- which is fixed by this PR -- where if called with instances of a derived array type (e.g. ``rt.Categorical``) defining it's own ``hstack()`` _classmethod_, and the derived array type's ``hstack()`` method raises an exception, ``rt.hstack()`` catches and suppresses the exception then falls back to the standard implementation. In addition to suppressing exceptions indicating bad/incompatible inputs (such as ``Categorical`` instances with different ``CategoryMode`` values), the standard implementation won't do any special handling (if/as needed) required by certain derived array types, so the returned array object will be broken/corrupted.

The change in this PR fixes the issue by checking for the presence of an ``hstack()`` method on the derived array class in a different way, and if found, that method is called without the ``try``/``except`` so any exceptions it throws propagate back to the caller of ``rt.hstack()``.