### PR TITLE
Fix for #136

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -1946,6 +1946,7 @@ class Categorical(GroupByOps, FastArray):
     # ------------------------------------------------------------
     @property
     def _fa(self):
+        # TODO: Just use self._view_internal(type=FastArray) here?
         result = self.view(FastArray)
         _copy_name(self, result)
         return result
@@ -4941,6 +4942,21 @@ class Categorical(GroupByOps, FastArray):
         # python has trouble deleting objects with circular references
         del self._categories_wrap
         self._grouping = None
+
+    def _view_internal(self, type: Optional[type] = None):
+        if type is None or type == Categorical:
+            # Return a shallow copy of this instance.
+            # The returned view will have the same array name as this instance.
+            return self.copy(deep=False)
+
+        elif type == FastArray:
+            # The Categorical._fa property already creates and returns a FastArray view of
+            # the underlying array representation, so it's safe to return directly.
+            return self._fa
+
+        else:
+            # It doesn't seem sensible to re-interpret a Categorical as any other type.
+            raise ValueError(f"Creating a '{type.__qualname__}'-typed view of a Categorical is not supported.")
 
     # ------------------------------------------------------------
     @classmethod

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2539,11 +2539,52 @@ class DateTime_Test(unittest.TestCase):
         # DateTimeNano-specific checks
         self.assertEqual(arr._timezone, arr_view._timezone)
 
+    def test_datetimenano_view_internal_unspecified_type(self) -> None:
+        """Test how DateTimeNano._view_internal() behaves when an output type is not explicitly specified."""
+        arr = DateTimeNano(
+            [
+                '20191119 09:30:17.557593707',
+                '20191119 15:31:32.216792000',
+                '20191121 11:28:23.519020994',
+                '20191121 11:28:56.822878000',
+                '20191121 14:01:39.112893000',
+                '20191121 15:46:10.838007105',
+                '20191122 11:53:05.974525000',
+                '20191125 10:40:32.079135847',
+                '20191126 10:00:43.232329062',
+                '20191126 14:04:31.421071000',
+            ],
+            from_tz='NYC',
+            to_tz='NYC',
+        )
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr._view_internal()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # DateTimeNano-specific checks
+        self.assertEqual(arr._timezone, arr_view._timezone)
+
     def test_date_view_unspecified_type(self) -> None:
         """Test how Date.view() behaves when an output type is not explicitly specified."""
         arr = Date(['2019-11-04', '2019-11-04', '2019-11-04', '2019-11-11'])
         arr.set_name(f"my_test_{type(arr).__name__}")
         arr_view = arr.view()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # Date-specific checks
+        # (None)
+
+    def test_date_view_internal_unspecified_type(self) -> None:
+        """Test how Date._view_internal() behaves when an output type is not explicitly specified."""
+        arr = Date(['2019-11-04', '2019-11-04', '2019-11-04', '2019-11-11'])
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr._view_internal()
         self.assertEqual(type(arr), type(arr_view))
         self.assertEqual(arr.shape, arr_view.shape)
         self.assertFalse(arr_view.flags.owndata)
@@ -2573,6 +2614,29 @@ class DateTime_Test(unittest.TestCase):
         self.assertTrue((arr == arr_view).all())
         # TimeSpan-specific checks
         # (None)
+
+    def test_timespan_view_internal_unspecified_type(self) -> None:
+        """Test how Date._view_internal() behaves when an output type is not explicitly specified."""
+        arr = TimeSpan([
+            '09:30:17.557593707',
+            '15:31:32.216792000',
+            '11:28:23.519020994',
+            '19:46:10.838007105',
+            '09:30:29.999999999',
+            '10:40:00.000000000',
+            '00:00:00.999999999',
+            '23:59:59.999999999',
+        ])
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr._view_internal()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # TimeSpan-specific checks
+        # (None)
+
 
 class TestTimeZone(unittest.TestCase):
     def test_equal_positive(self) -> None:
@@ -2606,7 +2670,6 @@ class TestTimeZone(unittest.TestCase):
         # exception being raised) and that it returns a reasonable result.
         test_tz_repr = repr(test_tz)
         self.assertEqual(test_tz_repr, "TimeZone(from_tz='NYC', to_tz='GMT')")
-
 
 
 # TODO RIP-486 add tests for other date types from rt_datetime

--- a/riptable/tests/test_fastarray.py
+++ b/riptable/tests/test_fastarray.py
@@ -1501,6 +1501,17 @@ class FastArray_Test(unittest.TestCase):
         self.assertEqual(arr.get_name(), arr_view.get_name())
         self.assertTrue((arr == arr_view).all())
 
+    def test_view_internal_unspecified_type(self) -> None:
+        """Test how FastArray._view_internal() behaves when an output type is not explicitly specified."""
+        arr = FastArray([6, 8, 10, 10, 0, 5, 2], dtype=np.uint32)
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr._view_internal()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+
 # TODO: Extend the tests in the TestFastArrayNanmax / TestFastArrayNanmin classes below to cover the following cases:
 #   * non-array inputs (e.g. a list or set or scalar)
 #   * other FastArray subclass, e.g. Date

--- a/riptable/tests/test_saveload.py
+++ b/riptable/tests/test_saveload.py
@@ -10,7 +10,7 @@ from riptable import *
 from riptable.rt_enum import CategoryMode, SDSFlag
 from riptable.rt_sds import SDSMakeDirsOn
 from riptable.Utils.rt_metadata import MetaData
-from riptable.Utils.rt_testing import assert_array_equal_, assert_categorical_equal, name
+from riptable.Utils.rt_testing import assert_array_equal_, name
 from riptable.Utils.rt_testdata import load_test_data
 
 from riptable.tests.test_utils import get_all_categorical_data
@@ -1320,7 +1320,14 @@ def test_sds_stack_with_categorical(container_type, data, stack, stack_count, tm
 
         act = actual[key]
         if isinstance(exp, Categorical):
-            assert_categorical_equal(act, exp, verbose=True)
+            assert_array_or_cat_equal(
+                act, exp,
+                err_msg=f"Data does not match up for key '{key}'.",
+                # Categories may not exactly be equal (they may be a subset of one another, for example),
+                # perhaps because some categories aren't actually used. Use the relaxed check which only
+                # cares that the categories match up for the actual data.
+                relaxed_cat_check=True
+            )
         elif isinstance(exp, Struct):
             assert act.equals(exp)
         else:
@@ -1371,7 +1378,14 @@ def test_sds_stack(data, stack, stack_count, tmpdir):
                   f'expected of type {type(data)}\n{repr(data)}' + \
                   f'actual of type {type(act)}\n{repr(act)}'
         if isinstance(exp, Categorical):
-            assert_categorical_equal(act, exp, verbose=True)
+            assert_array_or_cat_equal(
+                act, exp,
+                err_msg=f"Data does not match up for key '{k}'.",
+                # Categories may not exactly be equal (they may be a subset of one another, for example),
+                # perhaps because some categories aren't actually used. Use the relaxed check which only
+                # cares that the categories match up for the actual data.
+                relaxed_cat_check=True
+            )
         elif isinstance(exp, FastArray):
             assert_array_equal_(act, exp, err_msg=err_msg)
         elif isinstance(data, Struct):


### PR DESCRIPTION
This change fixes issue #136 by utilizing the ``FastArray._view_internal()`` method to create the view on ``FastArray`` (and derived types) arrays rather than calling the inherited ``ndarray.view()`` method which doesn't copy over the additional data needed by some array types.

This PR also includes a couple of related / prerequisite fixes:
* The ``FastArray._view_internal()`` method better handles the case where it's called with ``type=None`` -- at least in some cases, doing so before caused an exception to be raised even for a simple ``FastArray``.
* The ``Categorical`` class now implements an override of the ``_view_internal()`` method, which allows it to make use of it's own ``.copy()`` method to make a shallow copy. This is effectively making a view but importantly it also shallow-copies the ``Grouping`` object carried in the ``_grouping`` attribute, so if the original ``Categorical`` is deleted / cleaned up, the view's ``Grouping`` stays intact (vs. sharing the exact same object, where the view would be left with a ``Grouping`` that may not be in a usable state after being deleted).