### PR TITLE
Disable numba caching due to related segfaults reported by users.

### DIFF
--- a/riptable/config.py
+++ b/riptable/config.py
@@ -1,0 +1,47 @@
+"""
+General-purpose settings for configuring riptable behavior.
+
+This module provides a class encapsulating riptable settings and
+feature flags, along with functions for retrieving a top-level,
+process-wide instance of the class.
+"""
+__all__ = [
+    'Settings',
+    'get_global_settings'
+]
+
+from typing import NamedTuple
+
+
+# TODO: Make this a frozen @dataclass once riptable only supports Python 3.7+.
+#       Once the change is made, we can also implement a function which looks for environment
+#       variables (e.g. "RIPTABLE_ENABLE_NUMBA_CACHE", "RIPTABLE_MAX_NUM_THREADS") specifying
+#       overrides for default values, then creates the global Settings instance accordingly.
+class Settings(NamedTuple):
+    """
+    Encapsulates process-wide settings and feature-flags for riptable.
+    """
+
+    enable_numba_cache: bool = False
+    """
+    Controls whether the numba JIT cache is enabled for functions within riptable.
+    This is disabled (False) by default because the caching can lead to occasional
+    segfaults in numba-compiled code for some users, possibly caused by a race condition
+    or filesystem non-atomicity.
+    """
+
+
+__global_settings = Settings()
+"""Global (process-wide) `Settings` instance."""
+
+
+def get_global_settings() -> Settings:
+    """
+    Get the global (process-wide) `Settings` instance.
+
+    Returns
+    -------
+    Settings
+        Global (process-wide) settings.
+    """
+    return __global_settings

--- a/riptable/rt_merge.py
+++ b/riptable/rt_merge.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Collection, Dict, List, NamedTuple, Optional, 
 import numpy as np
 import numba as nb
 
+from .config import get_global_settings
 from .rt_utils import alignmk, mbget, merge_prebinned, get_default_value
 from .rt_timers import GetNanoTime
 from .rt_numpy import (
@@ -548,7 +549,7 @@ def _get_keep_ncountgroup(grouping: 'Grouping', keep: Optional[str]) -> FastArra
 # TODO: There seems to be some flakiness or race condition when parallel=True for this function;
 #       the output is sometimes different given the same inputs, which leads to correctness issues.
 #       The issue does not occur when parallel=False or when NUMBA_DISABLE_JIT=1 is set (to disable jitting).
-@nb.njit(parallel=False, cache=True, nogil=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def _build_right_fancyindex_impl(
     left_rows_with_right_keyids: np.ndarray,
     right_iFirstGroup: np.ndarray,
@@ -604,7 +605,7 @@ def _build_right_fancyindex_impl(
                     right_fancyindex[fancy_row_offset + i] = right_iGroup[curr_group_offset + i]
 
 
-@nb.njit(parallel=True, cache=True, nogil=True)
+@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
 def _fancy_index_fetch_keymap(left_keyid_to_right_keyid_map: np.ndarray, left_ikey: np.ndarray, invalid_value: int, output: np.ndarray):
     """
     This function is a temporary, performance-oriented workaround for the left<->right key mappings being
@@ -788,7 +789,7 @@ def _build_right_fancyindex(
     return right_fancyindex
 
 
-@nb.njit(parallel=True, cache=True, nogil=True)
+@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
 def _partial_repeat(arr: np.ndarray, repeats_cumsum: np.ndarray, output: np.ndarray):
     """
     Partial implementation of np.repeat.
@@ -834,7 +835,7 @@ def _partial_repeat(arr: np.ndarray, repeats_cumsum: np.ndarray, output: np.ndar
             output[output_start_index + j] = arr[i]
 
 
-@nb.njit(parallel=True, cache=True, nogil=True)
+@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
 def _fused_arange_repeat(repeats_cumsum: np.ndarray, output: np.ndarray):
     """
     Fused implementation of np.arange and np.repeat.

--- a/riptable/rt_str.py
+++ b/riptable/rt_str.py
@@ -1,10 +1,15 @@
-__all__ = ['FAString', ]
+__all__ = [
+    'FAString'
+]
 
 import numpy as np
 import numba as nb
+
+from .config import get_global_settings
 from .rt_fastarray import FastArray
 from .rt_numpy import empty_like, empty
 from .rt_enum import TypeRegister
+
 
 # NOTE YOU MUST INSTALL tbb
 # conda install tbb
@@ -31,7 +36,7 @@ from .rt_enum import TypeRegister
 # Keeping it as 1d and remembering the itemsize is 10% faster on large arrays, and even faster on small arrays
 # If recycling kicks in (only works on 1d arrays), it is 30% faster
 # Also note: On Windows as of Aug 2019, prange is much slower without tbb installed
-# 
+#
 # subclass from FastArray
 class FAString(FastArray):
     def __new__(cls, arr, ikey=None, **kwargs):
@@ -174,7 +179,7 @@ class FAString(FastArray):
         return self._apply_func(func, func, *args, dtype=dtype, input=self)
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_upper_inplace(src, itemsize):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -188,7 +193,7 @@ class FAString(FastArray):
                     src[rowpos+j] = c-32
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_upper(src, itemsize, dest):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -203,7 +208,7 @@ class FAString(FastArray):
                     dest[rowpos+j] = c
 
     # -----------------------------------------------------
-    @nb.jit(parallel=True, nopython=True, cache=True)
+    @nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache)
     def nb_pupper(src, itemsize, dest):
         # loop over all rows
         for i in nb.prange(np.int64(len(src) / itemsize)):
@@ -218,7 +223,7 @@ class FAString(FastArray):
                     dest[rowpos+j] = c
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_lower(src, itemsize, dest):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -233,7 +238,7 @@ class FAString(FastArray):
                     dest[rowpos+j] = c
 
     # -----------------------------------------------------
-    @nb.jit(parallel=True, nopython=True, cache=True)
+    @nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache)
     def nb_plower(src, itemsize, dest):
         # loop over all rows
         for i in nb.prange(len(src) / itemsize):
@@ -248,7 +253,7 @@ class FAString(FastArray):
                     dest[rowpos+j] = c
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_removetrailing(src, itemsize, dest, removechar):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -270,7 +275,7 @@ class FAString(FastArray):
 
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_reverse_inplace(src, itemsize):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -290,7 +295,7 @@ class FAString(FastArray):
                 end -= 1
 
     # -----------------------------------------------------
-    @nb.jit( cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_reverse(src, itemsize, dest):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -311,7 +316,7 @@ class FAString(FastArray):
 
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_strlen(src, itemsize, dest):
         # loop over all rows
         for i in range(len(src) / itemsize):
@@ -327,7 +332,7 @@ class FAString(FastArray):
             dest[i] = strlen
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_strpbrk(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -350,7 +355,7 @@ class FAString(FastArray):
                 dest[i] = -1
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_strstr(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -375,7 +380,7 @@ class FAString(FastArray):
                     break
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_strstrb(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -398,7 +403,7 @@ class FAString(FastArray):
                     break
 
     # -----------------------------------------------------
-    @nb.jit(parallel=True, nopython=True, cache=True)
+    @nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache)
     def nb_pstrstrb(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -421,7 +426,7 @@ class FAString(FastArray):
                     break
 
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_endswith(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -452,7 +457,7 @@ class FAString(FastArray):
                         dest[i] = True
                     
     # -----------------------------------------------------
-    @nb.jit(nopython=True, cache=True)
+    @nb.njit(cache=get_global_settings().enable_numba_cache)
     def nb_startswith(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows
@@ -474,7 +479,7 @@ class FAString(FastArray):
                     dest[i] = True
 
     # -----------------------------------------------------
-    @nb.jit(parallel=True, nopython=True, cache=True)
+    @nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache)
     def nb_pstartswith(src, itemsize, dest, str2):
         str2len = len(str2)
         # loop over all rows


### PR DESCRIPTION
A riptable user ran into a reproducible segfault in the numba-JIT-compiled
code for the fancy_index_fetch_keymap() function in merge, and was able to
definitively trace it back to numba's caching code. The issue is fairly rare
but since it's causing repeatable crashing for some users I'm disabling the
numba caching for riptable functions to provide a short-term (if not
long-term) fix.
This change also introduces a very simple settings/config class that could
be extended with additional configuration settings (to be controlled via
environment variables or some settings file); these would eventually be
used to populate _default_ values for various things like max number of
threads, which we normally auto-detect (and which the user can override),
but this'll allow users to override that auto-detection if they want to.