### PR TITLE
Fix ``_multistack_categoricals()`` so it works even if there are no defined categories

### DIFF
--- a/riptable/rt_sds.py
+++ b/riptable/rt_sds.py
@@ -995,8 +995,8 @@ def _multistack_categoricals(spec_name, meta_list, indices, listcats, idx_cutoff
         base_index = None
         indices, listcats = merge_cats(indices, listcats, unique_cutoffs=unique_cutoffs, from_mapping=True, ordered=ordered, verbose=SDSVerbose)
         # TJD added check
-        code=listcats[0][0]
-        if isinstance(code, (int, np.integer)):
+        # This check works even if the arrays returned in `listcats` are empty.
+        if np.issubdtype(listcats[0].dtype, np.integer):
             # EXCPECT first value is string, and second is int
             newcats = dict(zip(listcats[1], listcats[0]))
         else:


### PR DESCRIPTION
A user was running into an error when trying to load some data; I traced it back to the ``_multistack_categoricals()`` function in rt_sds.py making an assumption that the category arrays will always be non-empty for a ``Dictionary`` or ``IntEnum``-mode ``Categorical``.

The fix is to just check the dtype of one of the category arrays rather than extracting the first element and using ``isinstance()`` on it.