### PR TITLE
Fix for #161.

### DIFF
--- a/riptable/rt_grouping.py
+++ b/riptable/rt_grouping.py
@@ -3231,7 +3231,8 @@ class Grouping:
         else:
             if accum2:
                 raise TypeError(f"Nothing was calculated for Accum2 operation.")
-            print("Warning: nothing calculated.")
+            elif Grouping.DebugMode:
+                print("Warning: nothing calculated.")
 
         #create a new dataset from the groupby results
         if Grouping.DebugMode: print("calculateallpacked!", len(accum[0]), accum)


### PR DESCRIPTION
Move printing of warning message behind a check for ``Grouping.DebugMode`` like similar messages elsewhere in the file.