### PR TITLE
Use ``default_rng()`` in ``.sample()`` methods for better performance

### DIFF
--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -4388,8 +4388,11 @@ class Dataset(Struct):
             i += max_cols
 
     # -------------------------------------------------------
-    def sample(self, N: int = 10, filter=None) -> 'Dataset':
-        return sample(self, N=N, filter=filter)
+    def sample(
+            self, N: int = 10, filter: Optional[np.ndarray] = None,
+            seed: Optional[Union[int, Sequence[int], np.random.SeedSequence, np.random.Generator]] = None
+    ) -> 'Dataset':
+        return sample(self, N=N, filter=filter, seed=seed)
 
     # -------------------------------------------------------
     def _get_columns(self, cols: Union[str, Iterable[str]]) -> List[FastArray]:

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -169,6 +169,7 @@ def _ASTYPE(self, dtype):
 
     return self.astype(dtype)
 
+
 #--------------------------------------------------------------
 #--------------------------------------------------------------
 class FastArray(np.ndarray):
@@ -1108,7 +1109,10 @@ class FastArray(np.ndarray):
         return ret
 
     #--------------------------------------------------------------------------
-    def sample(self, N=10, filter=None):
+    def sample(
+        self, N: int = 10, filter: Optional[np.ndarray] = None,
+        seed: Optional[Union[int, Sequence[int], np.random.SeedSequence, np.random.Generator]] = None
+    ):
         '''
         Examples
         --------
@@ -1116,7 +1120,7 @@ class FastArray(np.ndarray):
         >>> a.sample(3)
         FastArray([0, 4, 9])
         '''
-        return sample(self, N=N, filter=filter)
+        return sample(self, N=N, filter=filter, seed=seed)
 
     #--------------------------------------------------------------------------
     def duplicated(self, keep='first', high_unique=False):

--- a/riptable/tests/test_rtnumpy.py
+++ b/riptable/tests/test_rtnumpy.py
@@ -186,34 +186,32 @@ class TestRTNumpy:
     def test_sample(self):
         # Test Dataset.sample
         ds = rt.Dataset({'num': [1, 2, 3, 4, 5], 'str': ['ab', 'bc', 'cd', 'de', 'ef']})
-        np.random.seed(1)
-        ds_sample = ds.sample(3, rt.FA([True, True, True, False, True]))
-        ds_sample_expected = rt.Dataset({'num': [1, 3, 5], 'str': ['ab', 'cd', 'ef']})
-        assert (ds_sample_expected == ds_sample).all(axis=None)
+        ds_sample = ds.sample(3, rt.FA([True, True, True, False, True]), seed=1)
+        ds_sample_expected = rt.Dataset({'num': [1, 2, 5], 'str': ['ab', 'bc', 'ef']})
+        assert ds_sample.keys() == ds_sample_expected.keys()
+        for col_name in ds_sample_expected.keys():
+            assert_array_equal(ds_sample_expected[col_name], ds_sample[col_name], err_msg=f"Column '{col_name}' differs.")
 
         # Test FastArray.sample
         fa = rt.FA([1, 2, 3, 4, 5])
-        np.random.seed(1)
-        fa_sample = fa.sample(2, rt.FA([False, True, True, False, True]))
-        fa_sample_expected = rt.FA([2, 5])
-        assert (fa_sample_expected == fa_sample).all(axis=None)
+        fa_sample = fa.sample(2, rt.FA([False, True, True, False, True]), seed=1)
+        fa_sample_expected = rt.FA([2, 3])
+        assert_array_equal(fa_sample_expected, fa_sample)
 
         # Test overflow
-        fa_sample = fa.sample(10, rt.FA([False, True, False, False, True]))
+        fa_sample = fa.sample(10, rt.FA([False, True, False, False, True]), seed=1)
         fa_sample_expected = rt.FA([2, 5])
-        assert (fa_sample_expected == fa_sample).all(axis=None)
+        assert_array_equal(fa_sample_expected, fa_sample)
 
         # Test no filter
-        np.random.seed(1)
-        fa_sample = fa.sample(2)
+        fa_sample = fa.sample(2, seed=1)
         fa_sample_expected = rt.FA([2, 3])
-        assert (fa_sample_expected == fa_sample).all(axis=None)
+        assert_array_equal(fa_sample_expected, fa_sample)
 
         # Test fancy index
-        np.random.seed(1)
-        fa_sample = fa.sample(2, rt.FA([1, 3, 4]))
-        fa_sample_expected = rt.FA([2, 5])
-        assert (fa_sample_expected == fa_sample).all(axis=None)
+        fa_sample = fa.sample(2, rt.FA([1, 3, 4]), seed=1)
+        fa_sample_expected = rt.FA([2, 4])
+        assert_array_equal(fa_sample_expected, fa_sample)
 
     def test_hstack_returns_same_type(self):
         # Create some instances of the same derived array type.


### PR DESCRIPTION
Use ``default_rng()`` in ``.sample()`` methods for better performance.