### PR TITLE
Fixes for numpy 1.20 / 1.21 compatibility

### DIFF
--- a/riptable/Utils/common.py
+++ b/riptable/Utils/common.py
@@ -20,7 +20,7 @@ the benchmarks while also allowing the benchmarks to be repeatable.
 
 _INT_16_MAX = np.iinfo(np.int16).max
 _INT_32_MAX = np.iinfo(np.int32).max
-_INT_MAX = np.int(1 << 33)  # 8_589_934_592
+_INT_MAX = np.int64(1 << 33)  # 8_589_934_592
 
 
 def trial_size(low=250, high=_INT_16_MAX, scale_factor=2):

--- a/riptable/Utils/common.py
+++ b/riptable/Utils/common.py
@@ -80,7 +80,7 @@ def integer_valid_range(dtype: np.dtype) -> Tuple[int, int]:
         raise ValueError(f"'{dtype}' is not an integral/integer dtype.")
 
     # Handle bool specially
-    if dtype == np.bool:
+    if np.issubdtype(dtype, bool):
         return (0, 1)
 
     # Get the info for this integer dtype
@@ -114,7 +114,7 @@ def integer_range(dtype: np.dtype, include_invalid: bool = False) -> Tuple[int, 
         raise ValueError(f"'{dtype}' is not an integral/integer dtype.")
 
     # Handle bool specially
-    if dtype == np.bool:
+    if np.issubdtype(dtype, bool):
         return (0, 1)
 
     # Determine the range based on whether the caller wants to include

--- a/riptable/Utils/rt_display_nested.py
+++ b/riptable/Utils/rt_display_nested.py
@@ -218,8 +218,9 @@ class DisplayNested:
                 elif type(v) == TypeRegister.Categorical:
                     item_formatter = _cat_info
 
+                # TODO: Use np.isscalar() here instead?
                 elif isinstance(
-                    v, (int, float, bool, np.integer, np.floating, np.bool, str, bytes)
+                    v, (int, float, bool, np.bool_, np.integer, np.floating, str, np.str_, bytes, np.bytes_)
                 ):
                     item_formatter = _scalar_info
 
@@ -274,8 +275,10 @@ class DisplayNested:
                         file_str += self.inline_svg['array']
                     file_str += f"<p>{k}"
                     file_str += f" {type(v).__name__} {_arr_info(v)}"  # {v.dtype}"
+
+                # TODO: Use np.isscalar() here instead?
                 elif isinstance(
-                    v, (int, float, bool, np.integer, np.floating, np.bool, str, bytes)
+                    v, (int, float, bool, np.bool_, np.integer, np.floating, str, np.str_, bytes, np.bytes_)
                 ):
                     if showicon:
                         file_str += self.inline_svg['object']

--- a/riptable/Utils/rt_testdata.py
+++ b/riptable/Utils/rt_testdata.py
@@ -335,7 +335,7 @@ class TestDataMeta(type):
         if cls._rand_bool is not None and len(cls._rand_bool) != cls.length:
             cls._rand_bool = None
         if cls._rand_bool is None:
-            cls._rand_bool = np.random.randint(0, 2, cls.length, dtype=np.bool).view(
+            cls._rand_bool = np.random.randint(0, 2, cls.length, dtype=bool).view(
                 treg.FastArray
             )
         return cls._rand_bool

--- a/riptable/benchmarks/rand_keydata.py
+++ b/riptable/benchmarks/rand_keydata.py
@@ -449,7 +449,7 @@ class SCDArrayGen(Problem):
         xl = np.full(index_size, self.lo)
         xu = np.full(index_size, self.hi)
 
-        super().__init__(n_var=self.index_size, n_constr=2, xl=xl, xu=xu, type_var=np.int)
+        super().__init__(n_var=self.index_size, n_constr=2, xl=xl, xu=xu, type_var=int)
 
     def s_error(self, arr):
         return abs(self.s_metric(arr) - self.s)

--- a/riptable/rt_accum2.py
+++ b/riptable/rt_accum2.py
@@ -743,8 +743,8 @@ class Accum2(GroupByOps, FastArray):
                 im = im[1:,:]
 
             # create row and col mask, init to all True
-            boolmaskY = ones(len(totalsY), dtype=np.bool)
-            boolmaskX = ones(len(totalsX), dtype=np.bool)
+            boolmaskY = ones(len(totalsY), dtype=bool)
+            boolmaskX = ones(len(totalsX), dtype=bool)
 
             # do both horizontal and vertical calculations which are dirty
             newTotalsX, newTotalsY =  cls._apply_2d_operation(func, im, True)

--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -1913,7 +1913,7 @@ class Categorical(GroupByOps, FastArray):
         if self.base_index == 1:
             return self._fa == 0
         else:
-            return zeros(len(self),dtype=np.bool)
+            return zeros(len(self),dtype=bool)
 
     # ------------------------------------------------------------
     def set_name(self, name):
@@ -3144,7 +3144,7 @@ class Categorical(GroupByOps, FastArray):
         elif self.isenum:
             return self.grouping.isin(x)
 
-        elif isinstance(values, (bool, np.bool, bytes, str, int, np.integer, float, np.floating)):
+        elif isinstance(values, (bool, np.bool_, bytes, str, int, np.integer, float, np.floating)):
             x = np.array([x])
         # numpy will find the common dtype (strings will always win)
         elif isinstance(x, (list, tuple)):

--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -698,7 +698,8 @@ class Categories:
         The Categorical instance will compare these integers to those in its underlying array to generate a boolean mask.
         """
         if self.issinglekey:
-            if isinstance(fld, (str, bytes, int, np.integer, float, np.float)):
+            # TODO: Simplify to use np.isscalar().
+            if isinstance(fld, (str, bytes, int, np.integer, float, np.float_)):
                 fld = [fld]
             string_matches = []
             for s in fld:

--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -5313,7 +5313,7 @@ class Dataset(Struct):
     #--------------------------------------------------------------------------
     @classmethod
     def concat_columns(cls, dsets, do_copy:bool, on_duplicate:str='raise', on_mismatch:str='warn'):
-        """
+        r"""
         Concatenates a list of Datasets or Structs horizontally.
 
         Parameters

--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -328,7 +328,7 @@ class Dataset(Struct):
                     if c == 'O':
                         # make sure, scalar type so no python objects like dicts come through
                         # try float, but most objects will flip to bytes or unicode
-                        if isinstance(v[0], (str, np.str, bytes, np.bytes_, int, float, bool, np.integer, np.floating, np.bool)):
+                        if isinstance(v[0], (str, np.str, bytes, np.bytes_, int, float, bool, np.integer, np.floating, np.bool_)):
                             try:
                                 # attempt to autodetect based on first element
                                 # NOTE: if the first element is a float and Nan.. does that mean keep looking?
@@ -339,8 +339,8 @@ class Dataset(Struct):
                                     v=v.astype('S')
                                 elif isinstance(v[0], (int, np.integer)):
                                     v=v.astype(np.int64)
-                                elif isinstance(v[0], (bool, np.bool)):
-                                    v=v.astype(np.bool)
+                                elif isinstance(v[0], (bool, np.bool_)):
+                                    v=v.astype(np.bool_)
                                 else:
                                     v = v.astype(np.float64)
                             except:
@@ -1364,7 +1364,7 @@ class Dataset(Struct):
         """
         # this is repeat code from FastArray isin, but this way, the values only need to be converted once for each column
         #x = values
-        #if isinstance(values, (bool, np.bool, bytes, str, int, np.integer, float, np.floating)):
+        #if isinstance(values, (bool, np.bool_, bytes, str, int, np.integer, float, np.floating)):
         #    x = np.array([x])
 
         ## numpy will find the common dtype (strings will always win)
@@ -2726,7 +2726,7 @@ class Dataset(Struct):
             return any(_col_any(_val) for _cn, _val in self.items())
         if axis == 1:
             # for each col,  !=0 to get back bool array.  then inplace OR all those results, careful with string arrays
-            temparray=zeros(len(self), dtype=np.bool)
+            temparray=zeros(len(self), dtype=bool)
             for arr in self.values():
                 if arr.dtype.num <= 13:
                     # inplace OR for numerical data
@@ -2790,7 +2790,7 @@ class Dataset(Struct):
         ifirstgroup= g['iFirstGroup']
         ncountgroup = g['nCountGroup']
 
-        result = ones(igroup.shape, dtype=np.bool)
+        result = ones(igroup.shape, dtype=bool)
 
         # return row of first occurrence
         if keep == 'first':
@@ -3017,7 +3017,7 @@ class Dataset(Struct):
             return all(_col_all(_val) for _cn, _val in self.items())
         if axis == 1:
             # for each col,  !=0 to get back bool array.  then inplace AND all those results, careful with string arrays
-            temparray=ones(len(self), dtype=np.bool)
+            temparray=ones(len(self), dtype=bool)
             for arr in self.values():
                 if arr.dtype.num <= 13:
                     # inplace AND for numerical data
@@ -4389,9 +4389,28 @@ class Dataset(Struct):
 
     # -------------------------------------------------------
     def sample(
-            self, N: int = 10, filter: Optional[np.ndarray] = None,
-            seed: Optional[Union[int, Sequence[int], np.random.SeedSequence, np.random.Generator]] = None
+        self, N: int = 10, filter: Optional[np.ndarray] = None,
+        seed: Optional[Union[int, Sequence[int], np.random.SeedSequence, np.random.Generator]] = None
     ) -> 'Dataset':
+        """
+        Select N random samples from `Dataset` or `FastArray`.
+
+        Parameters
+        ----------
+        N : int, optional, defaults to 10
+            Number of rows to sample.
+        filter : array-like (bool or rownums), optional, defaults to None
+            Filter for rows to sample.
+        seed : {None, int, array_like[ints], SeedSequence, Generator}, optional, defaults to None
+            A seed to initialize the `Generator`. If None, the generator is initialized using
+            fresh, random entropy data gathered from the OS.
+            See the docstring for `np.random.default_rng` for additional details.
+
+        Returns
+        -------
+        Dataset
+        """
+
         return sample(self, N=N, filter=filter, seed=seed)
 
     # -------------------------------------------------------

--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -328,11 +328,12 @@ class Dataset(Struct):
                     if c == 'O':
                         # make sure, scalar type so no python objects like dicts come through
                         # try float, but most objects will flip to bytes or unicode
-                        if isinstance(v[0], (str, np.str, bytes, np.bytes_, int, float, bool, np.integer, np.floating, np.bool_)):
+                        # TODO: Simplify to use np.isscalar() here?
+                        if isinstance(v[0], (str, np.str_, bytes, np.bytes_, int, float, bool, np.integer, np.floating, np.bool_)):
                             try:
                                 # attempt to autodetect based on first element
                                 # NOTE: if the first element is a float and Nan.. does that mean keep looking?
-                                if isinstance(v[0], (str, np.str)):
+                                if isinstance(v[0], (str, np.str_)):
                                     # NOTE this might get converted to 'S' if unicode is False for FastArrays
                                     v=v.astype('U')
                                 elif isinstance(v[0], (bytes, np.bytes_)):
@@ -5946,7 +5947,7 @@ class Dataset(Struct):
         >>> d = {'name': ['bob', 'mary', 'sue', 'john'],
         ...     'letters': [['A', 'B', 'C'], ['D'], ['E', 'F', 'G'], 'H']}
         >>> ds1 = rt.Dataset.from_jagged_dict(d)
-        >>> nd = rt.INVALID_DICT[np.dtype(np.str).num]
+        >>> nd = rt.INVALID_DICT[np.dtype(str).num]
         >>> ds2 = rt.Dataset({'name': ['bob', 'mary', 'sue', 'john'],
         ...     'letters0': ['A','D','E','H'], 'letters1': ['B',nd,'F',nd],
         ...     'letters2': ['C',nd,'G',nd]})

--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -295,19 +295,19 @@ class Dataset(Struct):
         --------
         String objects:
 
-        >>> ds = rt.Dataset({'col1': np.array(['a','b','c'], dtype=np.object)})
+        >>> ds = rt.Dataset({'col1': np.array(['a','b','c'], dtype=object)})
         >>> ds.col1
         FastArray([b'a', b'b', b'c'], dtype='|S1')
 
         Numeric objects:
 
-        >>> ds = rt.Dataset({'col1': np.array([1.,2.,3.], dtype=np.object)})
+        >>> ds = rt.Dataset({'col1': np.array([1.,2.,3.], dtype=object)})
         >>> ds.col1
         FastArray([1., 2., 3.])
 
         Mixed type objects:
 
-        >>> ds = rt.Dataset({'col1': np.array([np.nan, 'str', 1], dtype=np.object)})
+        >>> ds = rt.Dataset({'col1': np.array([np.nan, 'str', 1], dtype=object)})
         ValueError: could not convert string to float: 'str'
         TypeError: Cannot handle a numpy object array of type <class 'float'>
 
@@ -316,7 +316,7 @@ class Dataset(Struct):
 
         Mixed type objects starting with string:
 
-        >>> ds = rt.Dataset({'col1': np.array(['str', np.nan, 1], dtype=np.object)})
+        >>> ds = rt.Dataset({'col1': np.array(['str', np.nan, 1], dtype=object)})
         >>> ds.col1
         FastArray([b'str', b'nan', b'1'], dtype='|S3')
         """

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -4499,6 +4499,7 @@ class DateTimeNano(DateTimeBase, TimeStampBase, DateTimeCommon):
             Start year for range of random times. If no end year provided, all times will be within start year
         end : int, optional, default None
             End year for range of random times. Only used if `start` provided.
+
         Same as DateTimeNano.random(), but random invalid mask is also generated.
 
         Examples
@@ -4514,7 +4515,8 @@ class DateTimeNano(DateTimeBase, TimeStampBase, DateTimeCommon):
         --------
         DateTimeNano.random
         '''
-        inv = np.random.randint(0, 2, sz, dtype=np.bool)
+        # TODO: Use np.random.default_rng() here instead.
+        inv = np.random.randint(0, 2, sz, dtype=bool)
         return cls._random(sz, to_tz=to_tz, from_tz=from_tz, inv=inv, start=start, end=end)
 
     # -------------------------------------------------------------

--- a/riptable/rt_grouping.py
+++ b/riptable/rt_grouping.py
@@ -1250,7 +1250,7 @@ class Grouping:
             if isinstance(values, list):
                 # nothing passed in list?
                 if len(values) == 0:
-                    return zeros(result_len, dtype=np.bool), None
+                    return zeros(result_len, dtype=bool), None
 
                 # make separate arrays from each tuple index (rotate)
                 # how much error checking should happen here?
@@ -1266,7 +1266,7 @@ class Grouping:
 
             else:
                 # not found
-                mask = zeros(result_len, dtype=np.bool)
+                mask = zeros(result_len, dtype=bool)
                 et = empty(len(values), dtype=np.int32)
                 et.fill_invalid()
                 return mask, et
@@ -1318,7 +1318,7 @@ class Grouping:
 
         #if isinstance(values, list):
         #    if len(values) == 0:
-        #        return zeros(result_len, dtype=np.bool)
+        #        return zeros(result_len, dtype=bool)
         #    # make separate arrays from each tuple index (rotate)
         #    # how much error checking should happen here?
         #    if isinstance(values[0], tuple):
@@ -1332,7 +1332,7 @@ class Grouping:
         #    values = [ values ]
 
         #else:
-        #    mask = zeros(result_len, dtype=np.bool)
+        #    mask = zeros(result_len, dtype=bool)
 
         #if mask is None:
         #    # values is a list of arrays (single and multikey hit same path)

--- a/riptable/rt_hstack.py
+++ b/riptable/rt_hstack.py
@@ -153,7 +153,7 @@ def hstack_any(itemlist:Union[list, Mapping[str, np.ndarray]], cls:Optional[type
 
     #------------------------------
     def hstack_dict(itemdict, **kwargs):
-        '''
+        r"""
         Will create a Categorical from the keys in the dictionary.
 
         Examples
@@ -166,7 +166,7 @@ def hstack_any(itemlist:Union[list, Mapping[str, np.ndarray]], cls:Optional[type
         ...    mydict[f'cat{j}']=ds
         >>> z, mycat = rt.stack_rows(mydict)
         >>> z.mycat
-        '''
+        """
         dictlen = len(itemdict)
         if dictlen ==0:
             raise ValueError(f'List of dictionary items to stack was empty.')

--- a/riptable/rt_ledger.py
+++ b/riptable/rt_ledger.py
@@ -240,13 +240,13 @@ class MathLedger(Struct):
 
         if fastfunction == MATH_OPERATION.BITWISE_NOT:
             # speed up this common operation
-            if isinstance(tupleargs, tuple) and tupleargs[0].dtype == np.bool:
+            if isinstance(tupleargs, tuple) and tupleargs[0].dtype == bool:
                 return cls._BASICMATH_TWO_INPUTS(
                     (tupleargs[0], True, tupleargs[1]),
                     MATH_OPERATION.BITWISE_XOR,
                     final_num,
                 )
-            elif tupleargs.dtype == np.bool:
+            elif tupleargs.dtype == bool:
                 return cls._BASICMATH_TWO_INPUTS(
                     (tupleargs, True), MATH_OPERATION.BITWISE_XOR, final_num
                 )

--- a/riptable/rt_merge.py
+++ b/riptable/rt_merge.py
@@ -949,7 +949,7 @@ def _build_left_fancyindex(
             # TODO: As in code further down in this function, the creation of this array requires some workarounds to
             #       handle the difference between 0-based "key index" values and 1-based key ids that work more naturally
             #       with grouping arrays. This causes some additional allocations (and complexity) so should be cleaned up.
-            left_group_exists_in_right = full(left_keygroup.ncountgroup.shape, False, dtype=np.bool)
+            left_group_exists_in_right = full(left_keygroup.ncountgroup.shape, False, dtype=bool)
             left_group_exists_in_right[1:][right_keyid_to_left_keyid_map[right_key_exists_in_left]] = True
 
             if keep_left is None:
@@ -1133,7 +1133,7 @@ class JoinIndices(NamedTuple):
         """
         if index_arr is None:
             return dset_rowcount
-        elif index_arr.dtype == np.bool:
+        elif index_arr.dtype == bool:
             return sum(index_arr)
         else:
             return len(index_arr)
@@ -1287,7 +1287,7 @@ def _create_merge_fancy_indices(
         left_keyid_to_right_keyid_map[right_keyid_to_left_keyid_map[right_key_exists_in_left]] = bool_to_fancy(right_key_exists_in_left)
 
         # Get the rows from 'right' which have keys that aren't in 'left'.
-        right_only_group_mask = empty(right_keygroup.ncountgroup.shape, dtype=np.bool)
+        right_only_group_mask = empty(right_keygroup.ncountgroup.shape, dtype=bool)
         # Include the invalid/NA group from 'right', per definition of a full outer join.
         right_only_group_mask[0] = right_keygroup.ncountgroup[0] > 0
         right_only_group_mask[1:] = ~right_key_exists_in_left
@@ -3319,7 +3319,7 @@ class _AsOfMerge:
             #     f_forward = isnan(backward_distance)
             #     f_forward |= (forward_distance < backward_distance)
             #     f_forward &= isnotnan(forward_distance)
-            f_forward_closer = full(len(right_fancyindex_backward), False, dtype=np.bool)
+            f_forward_closer = full(len(right_fancyindex_backward), False, dtype=bool)
 
             # Determine the distance between the left_on and right_on columns in both the forward and backwards directions.
             # TODO: What should we do when the 'on' columns are integers and operations below underflow/overflow?

--- a/riptable/rt_numpy.py
+++ b/riptable/rt_numpy.py
@@ -89,7 +89,7 @@ def get_dtype(val):
         final = val.dtype
     except:
         if isinstance(val,bool):
-            final = np.dtype(np.bool)
+            final = np.dtype(bool)
 
         elif isinstance(val, int):
             val = abs(val)
@@ -149,7 +149,7 @@ def get_common_dtype(x, y) -> np.dtype:
     >>> get_common_type(arange(10), arange(10.0))
     dtype('float64')
 
-    >>> get_common_type(arange(10).astype(np.bool), True)
+    >>> get_common_type(arange(10).astype(bool), True)
     dtype('bool')
     """
     type1 = get_dtype(x)
@@ -224,7 +224,7 @@ def get_common_dtype(x, y) -> np.dtype:
     return common
 
 
-def empty(shape, dtype: Union[str, np.dtype, type] = np.float, order: str = 'C') -> 'FastArray':
+def empty(shape, dtype: Union[str, np.dtype, type] = float, order: str = 'C') -> 'FastArray':
     #return LedgerFunction(np.empty, shape, dtype=dtype, order=order)
 
     # make into list of ints
@@ -726,7 +726,7 @@ def ismember(a, b, h=2, hint_size: int = 0, base_index: int = 0) -> Tuple[Union[
     is_multikey = False
 
     if len_a == 0 or len_b == 0:
-        return zeros(len(a), dtype=np.bool), full(len_a, INVALID_DICT[np.dtype(np.int32).num])
+        return zeros(len(a), dtype=bool), full(len_a, INVALID_DICT[np.dtype(np.int32).num])
 
     if isinstance(a, TypeRegister.Categorical) or isinstance(b, TypeRegister.Categorical):
         if isinstance(a, TypeRegister.Categorical):
@@ -1458,7 +1458,7 @@ def groupbyhash(list_arrays, hint_size:int=0, filter=None, hash_mode:int=2, cuto
     A filter (boolean array) can be passed to ``groupbyhash``; this causes ``groupbyhash`` to only operate
     on the elements of the input array where the filter has a corresponding True value.
 
-    >>> f = (c % 3).astype(np.bool)
+    >>> f = (c % 3).astype(bool)
     >>> rt.groupbyhash(c, filter=f)
     {'iKey': FastArray([   0,    1,    2, ...,    0, 5250, 1973]),
      'iFirstKey': FastArray([    1,     2,     3, ..., 54422, 58655, 68250]),
@@ -1899,7 +1899,7 @@ def where(condition, x=None, y=None):
         # punt to normal numpy since more than one dimension
         return LedgerFunction(np.where,condition,x,y)
 
-    if condition.dtype != np.bool:
+    if condition.dtype != bool:
         #NOTE: believe numpy just flips it to boolean using astype, where object arrays handled differently with None and 0
         condition = condition != 0
 
@@ -2526,6 +2526,8 @@ def logical(a):
     if isinstance(a, np.ndarray):
         if a.dtype==np.bool_: return a
         return a.astype(np.bool_)
+    # TODO: Check for scalar here? Then we can be maybe use np.asanyarray(..., dtype=bool).view(TypeRegister.FastArray)
+    #       to replace the use of the deprecated `np.bool`.
     return np.bool(a).view(TypeRegister.FastArray)
 
 ##-------------------------------------------------------
@@ -2542,9 +2544,7 @@ class bool_(np.bool_):
     See Also
     --------
     np.bool_
-    np.bool
     """
-
     # Allow np.bool.inv  to work
     inv = INVALID_DICT[0]
 
@@ -2959,7 +2959,7 @@ def bitcount(a: Union[int, Sequence, np.array]) -> Union[int, np.array]:
         # check if we can use the fast routine
         if not isinstance(a, np.ndarray):
             a = np.asanyarray(a)
-        if np.issubdtype(a.dtype, np.integer) or a.dtype == np.bool:
+        if np.issubdtype(a.dtype, np.integer) or a.dtype == bool:
             if not a.flags.c_contiguous:
                 a = a.copy()
             return rc.BitCount(a)
@@ -3002,7 +3002,7 @@ def bool_to_fancy(arr: np.ndarray, both:bool=False):
     Examples
     --------
     >>> np.random.seed(12345)
-    >>> bools = np.random.randint(2, size=20, dtype=np.int8).astype(np.bool_)
+    >>> bools = np.random.randint(2, size=20, dtype=np.int8).astype(bool)
     >>> rt.bool_to_fancy(bools)
     FastArray([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 12, 15, 17, 18, 19])
 

--- a/riptable/rt_pdataset.py
+++ b/riptable/rt_pdataset.py
@@ -661,14 +661,14 @@ class PDataset(Dataset):
         slice(0, 1447138, None)
 
         '''
-        if isinstance(index, (int, np.int)):
+        if isinstance(index, (int, np.integer)):
             if index == 0:
                 return slice(0, self.pcutoffs[index])
             else:
                 return slice(self.pcutoffs[index - 1], self.pcutoffs[index])
 
         raise IndexError(
-            f'Cannot slice a parition with type {type(index)!r}.  Use an integer instead.'
+            f'Cannot slice a partition with type {type(index)!r}.  Use an integer instead.'
         )
 
     # -------------------------------------------------------
@@ -684,7 +684,7 @@ class PDataset(Dataset):
         >>> pds.partition(0)
         '''
 
-        if isinstance(index, (int, np.int)):
+        if isinstance(index, (int, np.integer)):
             # this will route to the dataset
             return self._copy(rows=self.pslice(index))
 
@@ -709,7 +709,7 @@ class PDataset(Dataset):
             return super().__getitem__(index)
         except:
             # if it fails, maybe it was a partition selection
-            if isinstance(index, (int, np.int)):
+            if isinstance(index, (int, np.integer)):
                 # convert int to string to lookup
                 index = str(index)
 

--- a/riptable/rt_sds.py
+++ b/riptable/rt_sds.py
@@ -1218,10 +1218,10 @@ def _convert_to_mask(filter):
             # convert fancy index to bool
             if len(filter) > 0:
                 maxval = np.max(filter)
-                mask = zeros(maxval + 1, dtype=np.bool)
+                mask = zeros(maxval + 1, dtype=bool)
                 mask[filter] = True
             else:
-                mask = zeros(0, dtype=np.bool)
+                mask = zeros(0, dtype=bool)
             return mask
     else:
         raise TypeError(f'The filter must be a numpy array of booleans or integers not {type(filter)}.')

--- a/riptable/rt_sds.py
+++ b/riptable/rt_sds.py
@@ -2074,7 +2074,7 @@ def skeleton_from_meta_data(container_type, filepath, meta, arrays, meta_tups, f
         elif dtypenum == 19:
             return np.dtype('U'+str(itemsize // 4))
         else:
-            return np.dtype(np.typeDict[dtypenum])
+            return np.dtype(np.sctypeDict[dtypenum])
 
     def info_to_struct(f):
         def wrapper(item_tup, sds_tup, filepath):

--- a/riptable/rt_sds.py
+++ b/riptable/rt_sds.py
@@ -328,7 +328,7 @@ def sds_endswith(path: Union[bytes, str, List[Union[bytes, str]]], add: bool = F
 
 #-----------------------------------------------------------------------------------------
 def sds_flatten(rootpath: AnyPath) -> None:
-    """
+    r"""
     `sds_flatten` brings all structs and nested structures in sub-directories into the main directory.
 
     Parameters
@@ -783,7 +783,7 @@ def _sds_raw_info(filepath: AnyPath, share: Optional[Union[bytes, str]] = None, 
 
 #-----------------------------------------------------------------------------------------
 def sds_dir(filepath: AnyPath, share: Optional[str] = None) -> List[str]:
-    """
+    r"""
     Returns list of ``Dataset`` or ``Struct`` item names as strings.
     Only returns top level item names of ``Struct`` directory.
 
@@ -825,7 +825,7 @@ def sds_info(filepath: Union[AnyPath, Sequence[AnyPath]], share: Optional[Union[
 
 #-----------------------------------------------------------------------------------------
 def sds_tree(filepath: AnyPath, threads: Optional[int] = None):
-    '''
+    r'''
     Explicitly display a tree of data for .sds file or directory.
     Only loads info, not data.
 
@@ -1266,7 +1266,7 @@ def _stack_sds_files(filenames, share=None, info=False, include=None, folders=No
 
 #-----------------------------------------------------------------------------------------
 def _stack_sds_dirs(filenames, share=None, info:bool=False, include=[], folders=[], sections=None, threads=None):
-    '''
+    r'''
     Dictionary will be created for final `rc.MultiStackFiles` call.
 
     >>> dirs = ['D:\junk\foobar\20190201', 'D:\junk\foobar\20190204', 'D:\junk\foobar\20190205']
@@ -1465,7 +1465,7 @@ def load_sds(
     verbose: bool = False,
     reserve: float = 0.0
 ) -> 'Struct':
-    """
+    r"""
     Load a dataset from single ``.sds`` file or struct from directory of ``.sds`` files.
 
     When ``stack=True``, generic loader for a single ``.sds`` file or directory of multiple ``.sds`` files.
@@ -1687,7 +1687,7 @@ def decompress_dataset_internal(
     mustexist: bool = False,
     goodfiles: Optional[Tuple[List[str], AnyPath]] = None
 ) -> List[Tuple[bytes, List[np.ndarray], List[tuple]]]:
-    """
+    r"""
     Parameters
     ----------
     filename : str or bytes or os.PathLike or sequence of str
@@ -2606,7 +2606,7 @@ def _load_sds(
 
 #------------------------------------------------------------------------------------
 def _sds_load_from_schema(schema, path, dir, filename=None, root=None, sharename=None, include=None, info=False, nocrawl=np.ndarray, multiload=None, multiload_idx=None, multiload_schema=None, threads=None):
-    '''
+    r'''
     Recursive function for loading data or info from .sds directory.
     Nested structures are stored:
 

--- a/riptable/rt_str.py
+++ b/riptable/rt_str.py
@@ -635,7 +635,7 @@ class FAString(FastArray):
                 return TypeError(f"A single string must be passed for str2 not {str2!r}")
             str2 = FAString(str2)
 
-        return self._apply_func(self.nb_contains, self.nb_contains_par, str2, dtype=np.bool)
+        return self._apply_func(self.nb_contains, self.nb_contains_par, str2, dtype=bool)
 
     def strstrb(self, str2):
         _warn_deprecated_naming('strstrb', 'contains')
@@ -665,7 +665,7 @@ class FAString(FastArray):
                 return TypeError(f"A single string must be passed for str2 not {str2!r}")
             str2 = FAString(str2)
 
-        return self._apply_func(self.nb_startswith, self.nb_startswith_par, str2, dtype=np.bool)
+        return self._apply_func(self.nb_startswith, self.nb_startswith_par, str2, dtype=bool)
 
     # -----------------------------------------------------
     def endswith(self, str2):
@@ -691,7 +691,7 @@ class FAString(FastArray):
                 return TypeError(f"A single string must be passed for str2 not {str2!r}")
             str2 = FAString(str2)
 
-        return self._apply_func(self.nb_endswith, self.nb_endswith_par, str2, dtype=np.bool)
+        return self._apply_func(self.nb_endswith, self.nb_endswith_par, str2, dtype=bool)
 
     def regex_match(self, regex):
         '''

--- a/riptable/rt_struct.py
+++ b/riptable/rt_struct.py
@@ -4147,7 +4147,7 @@ class Struct:
                     # cannot hstack string repr with column name
                     try:
                         if data.ndim == 1:
-                            items = data[:self._summary_len].astype(np.str)
+                            items = data[:self._summary_len].astype(str)
                         else:
                             items = np.array([str(i) for i in data[:self._summary_len]])
                     except:
@@ -4204,8 +4204,8 @@ class Struct:
             sizes.append(size)
             summary_items.append(items)
 
-        main_data = [np.array(names, dtype=np.str), np.array(types, dtype=np.str),
-                     np.array(sizes, dtype=np.str)]
+        main_data = [np.array(names, dtype=str), np.array(types, dtype=str),
+                     np.array(sizes, dtype=str)]
 
         summary_items = np.array(summary_items)
 

--- a/riptable/rt_struct.py
+++ b/riptable/rt_struct.py
@@ -1319,7 +1319,7 @@ class Struct:
         '''
         info_str = ['scalar']
         typename = scalar_tup[1]
-        typename = str(np.typeDict[typename].__name__)
+        typename = str(np.sctypeDict[typename].__name__)
         itemsize = str(scalar_tup[3])
 
         info_str.append(typename)
@@ -1340,7 +1340,7 @@ class Struct:
         info_str = []
         info_str.append("FA")
         info_str.append(str(shape))
-        info_str.append(str(np.typeDict[typenum].__name__))
+        info_str.append(str(np.sctypeDict[typenum].__name__))
         info_str.append("i"+str(itemsize))
         return info_str
 

--- a/riptable/rt_timezone.py
+++ b/riptable/rt_timezone.py
@@ -437,10 +437,10 @@ class TimeZone:
         if cutoffs is None:
             cutoffs = self._dst_cutoffs
         if cutoffs is None:
-            return zeros(len(arr), dtype=np.bool)
+            return zeros(len(arr), dtype=bool)
 
-        #is_dst = (FastArray(np.searchsorted(DST_CUTOFFS, arr)) & 1).astype(np.bool)
-        #is_dst = (rc.BinsToCutsBSearch(arr, cutoffs, 0) & 1).astype(np.bool)
+        #is_dst = (FastArray(np.searchsorted(DST_CUTOFFS, arr)) & 1).astype(bool)
+        #is_dst = (rc.BinsToCutsBSearch(arr, cutoffs, 0) & 1).astype(bool)
 
         is_dst = (searchsorted(cutoffs, arr) & 1).astype(np.bool_)
         return is_dst

--- a/riptable/rt_utils.py
+++ b/riptable/rt_utils.py
@@ -987,6 +987,10 @@ def sample(
         Number of rows to sample.
     filter : array-like (bool or rownums), optional
         Filter for rows to sample.
+    seed : {None, int, array_like[ints], SeedSequence, Generator}, optional, defaults to None
+        A seed to initialize the `Generator`. If None, the generator is initialized using
+        fresh, random entropy data gathered from the OS.
+        See the docstring for `np.random.default_rng` for additional details.
 
     Returns
     -------

--- a/riptable/tests/test_categorical_filter_invalid.py
+++ b/riptable/tests/test_categorical_filter_invalid.py
@@ -173,7 +173,7 @@ class TestCategoricalFilterInvalid:
 
         # same uniques
         arr = np.random.choice(['a', 'b', 'c'], 50)
-        filter = ones(50, dtype=np.bool)
+        filter = ones(50, dtype=bool)
         filter[:5] = False
         c = Categorical(arr)
         c_pre = Categorical(arr, filter=filter)

--- a/riptable/tests/test_dataset.py
+++ b/riptable/tests/test_dataset.py
@@ -228,8 +228,8 @@ class TestDataset(unittest.TestCase):
             self.assertEqual(ds1[_k].dtype, np.dtype(np.int16))
         for _k in list('US'):
             self.assertEqual(ds1[_k].dtype, dtypes0[_k])
-        ds.S = ds.A.astype(np.str)
-        ds.S = ds.B.astype(np.str)
+        ds.S = ds.A.astype(str)
+        ds.S = ds.B.astype(str)
         # 9/28/2018 SJK: Dataset no longer flips Unicode arrays to Categorical, removed unicode column
         ds1 = ds.astype(np.float16, ignore_non_computable=True)
         for _k in list('ABCG'):
@@ -1560,7 +1560,7 @@ class TestDataset(unittest.TestCase):
 
     def test_arith_ops_08(self):
         ds1 = self.get_basic_dataset(nrows=100).astype(np.float32)
-        ds1.S = ds1.a.astype(np.str)
+        ds1.S = ds1.a.astype(str)
         ds2 = ds1.copy()
         ds1[2, :] /= 2
         self.assertTrue((ds1[2, :] == ds2[2, :] / 2).all(axis=None))

--- a/riptable/tests/test_dataset.py
+++ b/riptable/tests/test_dataset.py
@@ -1600,8 +1600,8 @@ class TestDataset(unittest.TestCase):
         df["B"] = df["A"].astype('category')
         ds = Dataset({'A': df.A, 'B': df.B})
         self.assertIsInstance(ds.B, TypeRegister.Categorical)
-        self.assertTrue((df.A == ds.A.astype(np.unicode)).all())
-        self.assertTrue((df.B == ds.B.as_string_array.astype(np.unicode)).all())
+        self.assertTrue((df.A == ds.A.astype(str)).all())
+        self.assertTrue((df.B == ds.B.as_string_array.astype(str)).all())
 
     def _test_output(self):
         ds = self.get_basic_dataset()[:4, :3]
@@ -1885,7 +1885,7 @@ class TestDataset(unittest.TestCase):
         ds = Dataset.from_pandas(df)
         self.assertIsInstance(ds.B, TypeRegister.Categorical)
         self.assertIsInstance(ds.C, TypeRegister.Categorical)
-        self.assertTrue((df.A == ds.A.astype(np.unicode)).all())
+        self.assertTrue((df.A == ds.A.astype(str)).all())
         for key in 'BCDEF':
             self.assertTrue((df[key] == _bytes_to_string(ds[key].expand_array)).all())
         for (key, tz) in [

--- a/riptable/tests/test_dataset_slicing.py
+++ b/riptable/tests/test_dataset_slicing.py
@@ -5,7 +5,6 @@ import unittest
 from riptable import Dataset, Cat
 from riptable.rt_enum import INVALID_DICT
 
-
 master_type_dict = {
     'bool': np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=bool),
     'int8': np.array(
@@ -220,7 +219,7 @@ master_type_dict = {
             INVALID_DICT[np.dtype('bytes').num],
             b'zkdfjlw',
             b'a',
-            b';][{}[\|||+=_-',
+            br';][{}[\|||+=_-',
             b'qwernvldkj',
             b'abefgkejf',
         ],
@@ -240,7 +239,7 @@ master_type_dict = {
             'rrrrn2fhfewl',
             'zkdfjlw',
             'a',
-            ';][{}[\|||+=_-',
+            r';][{}[\|||+=_-',
             'qwernvldkj',
             INVALID_DICT[np.dtype('str_').num],
         ],

--- a/riptable/tests/test_dataset_slicing.py
+++ b/riptable/tests/test_dataset_slicing.py
@@ -7,7 +7,7 @@ from riptable.rt_enum import INVALID_DICT
 
 
 master_type_dict = {
-    'bool': np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=np.bool),
+    'bool': np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=bool),
     'int8': np.array(
         [
             26,

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -1347,7 +1347,7 @@ class DateTime_Test(unittest.TestCase):
         with self.assertRaises(TypeError):
             dtn = DateTimeNano({1, 2, 3}, from_tz='NYC')
         with self.assertRaises(TypeError):
-            dtn = DateTimeNano(zeros(5, dtype=np.bool), from_tz='NYC')
+            dtn = DateTimeNano(zeros(5, dtype=bool), from_tz='NYC')
 
     def test_classname(self):
         dtn = DateTimeNano(['2000-01-01 00:00:00'], from_tz='NYC')

--- a/riptable/tests/test_fastarray.py
+++ b/riptable/tests/test_fastarray.py
@@ -63,7 +63,7 @@ array_sizes = [
 # these will break a lot of ufuncs because of division by zero, nans, etc.
 # TODO: add unit tests to make sure they break correctly
 numeric_types_with_invalid = {
-    'bool': FastArray([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=np.bool),
+    'bool': FastArray([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=bool),
     'int8': FastArray(
         [
             26,
@@ -268,7 +268,7 @@ numeric_types_with_invalid = {
 with warnings.catch_warnings():
     warnings.simplefilter('ignore', category=UserWarning)
     all_types = {
-        'bool': FastArray([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=np.bool),
+        'bool': FastArray([1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0], dtype=bool),
         'int8': FastArray(
             [
                 26,

--- a/riptable/tests/test_fastarray_bn.py
+++ b/riptable/tests/test_fastarray_bn.py
@@ -19,7 +19,7 @@ try:
     class FastArray_BN_Test(unittest.TestCase):
         def test_masking(self):
             np_bools = [
-                np.random.randint(low=0, high=2, size=10_000_000).astype(np.bool)
+                np.random.randint(low=0, high=2, size=10_000_000).astype(bool)
                 for i in range(6)
             ]
 

--- a/riptable/tests/test_groupby.py
+++ b/riptable/tests/test_groupby.py
@@ -26,7 +26,7 @@ arr_types = [
     np.float64,
 ]
 arr_types_string = [np.bytes_, np.str_]
-test_data = {'bool': np.array([True, False, True, False, True], dtype=np.bool)}
+test_data = {'bool': np.array([True, False, True, False, True], dtype=bool)}
 for dt in arr_types + arr_types_string:
     test_data[dt.__name__] = np.array(num_list, dtype=dt)
 test_data['categorical'] = Categorical([str(i) for i in num_list])

--- a/riptable/tests/test_grouping.py
+++ b/riptable/tests/test_grouping.py
@@ -612,7 +612,7 @@ class Grouping_Test(unittest.TestCase):
         data1 = rt.arange(len(key_data1))
 
         # Create a condition mask with all values set to False.
-        group_mask1 = rt.zeros(len(g1.ncountgroup), dtype=np.bool)
+        group_mask1 = rt.zeros(len(g1.ncountgroup), dtype=bool)
 
         # Extract elements from the data array with all groups masked out -- i.e. we're trying
         # to select data from none of the groups.

--- a/riptable/tests/test_merge.py
+++ b/riptable/tests/test_merge.py
@@ -1645,8 +1645,8 @@ def test_merge_create_fancy_indices_with_invalids(
     # Test #1: Filter every other row in both Categoricals. Use this as a rough bounds-check by comparing
     # the number of rows in this result to the original merge_result -- it should have at most the same
     # number of rows as the original.
-    left_filt = (np.arange(len(left_on)) % 2).astype(np.bool)
-    right_filt = (np.arange(len(right_on)) % 2).astype(np.bool)
+    left_filt = (np.arange(len(left_on)) % 2).astype(bool)
+    right_filt = (np.arange(len(right_on)) % 2).astype(bool)
 
     filtered_on = f'{on}_filtered'
 
@@ -1772,8 +1772,8 @@ def test_merge2_handles_invalids(
     # Test #1: Filter every other row in both Categoricals. We use this as a rough bounds-check by comparing
     # the number of rows in this result to the original merge_result -- it should have at most the same
     # number of rows as the original.
-    left_filt = (np.arange(len(left_on)) % 2).astype(np.bool)
-    right_filt = (np.arange(len(right_on)) % 2).astype(np.bool)
+    left_filt = (np.arange(len(left_on)) % 2).astype(bool)
+    right_filt = (np.arange(len(right_on)) % 2).astype(bool)
 
     filtered_on = f'{on}_filtered'
 

--- a/riptable/tests/test_rtnumpy.py
+++ b/riptable/tests/test_rtnumpy.py
@@ -368,7 +368,7 @@ class TestNanmax:
 
         # The result should either be a Python string, a numpy string scalar, or a Categorical scalar (if we implement one).
         is_py_str = isinstance(result, (bytes, str))
-        is_np_scalar = isinstance(result, np.str)
+        is_np_scalar = isinstance(result, (np.bytes_, np.str_))
         is_rt_cat = isinstance(result, rt.Categorical)
         assert is_py_str or is_np_scalar or is_rt_cat
 
@@ -446,7 +446,7 @@ class TestNanmin:
 
         # The result should either be a Python string, a numpy string scalar, or a Categorical scalar (if we implement one).
         is_py_str = isinstance(result, (bytes, str))
-        is_np_scalar = isinstance(result, np.str)
+        is_np_scalar = isinstance(result, (np.bytes_, np.str_))
         is_rt_cat = isinstance(result, rt.Categorical)
         assert is_py_str or is_np_scalar or is_rt_cat
 

--- a/riptable/tests/test_sprint_fastarray.py
+++ b/riptable/tests/test_sprint_fastarray.py
@@ -16,7 +16,7 @@ from math import isclose
 
 float_types = [np.float32, np.float64]
 int_types = [
-    np.bool,
+    np.bool_,
     np.int8,
     np.uint8,
     np.int16,
@@ -30,7 +30,7 @@ int_types = [
     np.uint64,
 ]
 string_types = [np.bytes_, np.str_]
-warning_types = [np.object, np.complex64, np.complex128, np.float16]
+warning_types = [object, np.complex64, np.complex128, np.float16]
 
 # nan_funcs   = [ np.nanargmax, np.nanargmin, np.nancumprod, np.nancumsum, np.nanmax,
 #                np.nanmean, np.nanmedian, np.nanmin, np.nanpercentile, np.nanprod,
@@ -49,7 +49,7 @@ invalid_data = [slice(1, 2, 3), ..., {'a': 1}]  # add type, elipses, dict
 np.random.seed(1234)
 
 
-def almost_eq(fa, arr, places=5, rtol=1e-5, atol=1e-5, equal_nan=True):
+def almost_eq(fa: FastArray, arr: np.ndarray, places=5, rtol=1e-5, atol=1e-5, equal_nan=True):
     epsilon = 10 ** (-places)
     rtol = epsilon
 
@@ -351,7 +351,7 @@ class FastArray_Test(unittest.TestCase):
         si64 = NumpyCharTypes.SignedInteger64
         f64 = NumpyCharTypes.Float64
         input_types = [
-            np.bool,
+            np.bool_,
             np.int8,
             np.uint8,
             np.int16,
@@ -595,7 +595,7 @@ class FastArray_Test(unittest.TestCase):
 
         num_types = int_types + float_types
         # TODO: add separate test for boolean arrays to prevent natural crash
-        # num_types.remove(np.bool)
+        # num_types.remove(np.bool_)
         math_ufuncs = [
             np.absolute,
             np.abs,

--- a/riptable/tests/test_str.py
+++ b/riptable/tests/test_str.py
@@ -90,7 +90,7 @@ class TestFAString:
         -3, 6, [0, 0, 0, 0, -5]
     ])
     def test_char_failure(self, position):
-        with pytest.raises(ValueError, match='Position -?\d out of bounds'):
+        with pytest.raises(ValueError, match=r'Position -?\d out of bounds'):
             FAString(SYMBOLS).char(position)
 
     @parametrize("str2, expected", [
@@ -231,7 +231,7 @@ class TestFAString:
 
     regex_match_test_cases = parametrize('regex, expected', [
         ('.', [True] * 5),
-        ('\.', [False] * 5),
+        (r'\.', [False] * 5),
         ('A', [True, True, False, False, False]),
         ('[A|B]', [True, True, True, False, True]),
         ('B$', [False, False, True, False, False]),

--- a/riptable/tests/test_ufunc2.py
+++ b/riptable/tests/test_ufunc2.py
@@ -51,7 +51,7 @@ class TestUfuncKwargs(object):
         assert_raises(ex_type, np.add, 1, 2, sig='ii->i', signature='ii->i')
 
     def test_sig_dtype(self):
-        ex_type = TypeError if _numpy_version >= (1, 21, 0) else ValueError
+        ex_type = TypeError if _numpy_version >= (1, 21, 0) else RuntimeError
         assert_raises(ex_type, np.add, 1, 2, sig='ii->i', dtype=int)
         assert_raises(ex_type, np.add, 1, 2, signature='ii->i', dtype=int)
 

--- a/riptable/tests/test_ufunc2.py
+++ b/riptable/tests/test_ufunc2.py
@@ -25,6 +25,9 @@ from numpy.testing import (
 from numpy.compat import pickle
 from riptable import FastArray as FA
 
+# riptable: small modification to allow this code to work with both older and newer
+#           versions of numpy [1.18, 1.21].
+_numpy_version = tuple(int(x) for x in np.version.version.split('.'))
 
 UNARY_UFUNCS = [
     obj for obj in np.core.umath.__dict__.values() if isinstance(obj, np.ufunc)
@@ -44,11 +47,13 @@ class TestUfuncKwargs(object):
         assert_raises(TypeError, np.add, 1, 2, wherex=[True])
 
     def test_sig_signature(self):
-        assert_raises(ValueError, np.add, 1, 2, sig='ii->i', signature='ii->i')
+        ex_type = TypeError if _numpy_version >= (1, 21, 0) else ValueError
+        assert_raises(ex_type, np.add, 1, 2, sig='ii->i', signature='ii->i')
 
     def test_sig_dtype(self):
-        assert_raises(RuntimeError, np.add, 1, 2, sig='ii->i', dtype=int)
-        assert_raises(RuntimeError, np.add, 1, 2, signature='ii->i', dtype=int)
+        ex_type = TypeError if _numpy_version >= (1, 21, 0) else ValueError
+        assert_raises(ex_type, np.add, 1, 2, sig='ii->i', dtype=int)
+        assert_raises(ex_type, np.add, 1, 2, signature='ii->i', dtype=int)
 
     def test_extobj_refcount(self):
         # Should not segfault with USE_DEBUG.

--- a/riptable/tests/test_ufunc2.py
+++ b/riptable/tests/test_ufunc2.py
@@ -1,30 +1,38 @@
 # This file is adapted for riptable from the following numpy source:
-# https://github.com/numpy/numpy/blob/6d9e294c47e790067e0b5724afecb4e38a542bd0/numpy/core/tests/test_ufunc.py
+# https://github.com/numpy/numpy/blob/f6a7a440669c6f386a1b15e081c6db740bb87a88/numpy/core/tests/test_ufunc.py
+from __future__ import division, absolute_import, print_function
+
 import warnings
 import itertools
-import sys
-
 import pytest
-
 import numpy as np
 import numpy.core._umath_tests as umt
 import numpy.linalg._umath_linalg as uml
 import numpy.core._operand_flag_tests as opflag_tests
 import numpy.core._rational_tests as _rational_tests
+import riptable as rt
+
 from numpy.testing import (
-    assert_, assert_equal, assert_raises, assert_array_equal,
-    assert_almost_equal, assert_array_almost_equal, assert_no_warnings,
-    assert_allclose, HAS_REFCOUNT,
-    )
+    assert_,
+    assert_equal,
+    assert_raises,
+    assert_array_equal,
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_no_warnings,
+    assert_allclose,
+)
 from numpy.compat import pickle
+from riptable import FastArray as FA
 
 
-UNARY_UFUNCS = [obj for obj in np.core.umath.__dict__.values()
-                    if isinstance(obj, np.ufunc)]
+UNARY_UFUNCS = [
+    obj for obj in np.core.umath.__dict__.values() if isinstance(obj, np.ufunc)
+]
 UNARY_OBJECT_UFUNCS = [uf for uf in UNARY_UFUNCS if "O->O" in uf.types]
 
 
-class TestUfuncKwargs:
+class TestUfuncKwargs(object):
     def test_kwarg_exact(self):
         assert_raises(TypeError, np.add, 1, 2, castingx='safe')
         assert_raises(TypeError, np.add, 1, 2, dtypex=int)
@@ -36,21 +44,18 @@ class TestUfuncKwargs:
         assert_raises(TypeError, np.add, 1, 2, wherex=[True])
 
     def test_sig_signature(self):
-        assert_raises(TypeError, np.add, 1, 2, sig='ii->i',
-                      signature='ii->i')
+        assert_raises(ValueError, np.add, 1, 2, sig='ii->i', signature='ii->i')
 
     def test_sig_dtype(self):
-        assert_raises(TypeError, np.add, 1, 2, sig='ii->i',
-                      dtype=int)
-        assert_raises(TypeError, np.add, 1, 2, signature='ii->i',
-                      dtype=int)
+        assert_raises(RuntimeError, np.add, 1, 2, sig='ii->i', dtype=int)
+        assert_raises(RuntimeError, np.add, 1, 2, signature='ii->i', dtype=int)
 
     def test_extobj_refcount(self):
         # Should not segfault with USE_DEBUG.
         assert_raises(TypeError, np.add, 1, 2, extobj=[4096], parrot=True)
 
 
-class TestUfuncGenericLoops:
+class TestUfuncGenericLoops(object):
     """Test generic loops.
 
     The loops to be tested are:
@@ -95,33 +100,41 @@ class TestUfuncGenericLoops:
     relevant functions.
 
     """
+
     np_dtypes = [
-        (np.single, np.single), (np.single, np.double),
-        (np.csingle, np.csingle), (np.csingle, np.cdouble),
-        (np.double, np.double), (np.longdouble, np.longdouble),
-        (np.cdouble, np.cdouble), (np.clongdouble, np.clongdouble)]
+        (np.single, np.single),
+        (np.single, np.double),
+        (np.csingle, np.csingle),
+        (np.csingle, np.cdouble),
+        (np.double, np.double),
+        (np.longdouble, np.longdouble),
+        (np.cdouble, np.cdouble),
+        (np.clongdouble, np.clongdouble),
+    ]
 
     # FA ready
     @pytest.mark.parametrize('input_dtype,output_dtype', np_dtypes)
     def test_unary_PyUFunc(self, input_dtype, output_dtype, f=np.exp, x=0, y=1):
         xs = np.full(10, input_dtype(x), dtype=output_dtype)
+        xs = FA(xs)
         ys = f(xs)[::2]
         assert_allclose(ys, y)
         assert_equal(ys.dtype, output_dtype)
 
     def f2(x, y):
-        return x**y
+        return x ** y
 
     # FA ready
     @pytest.mark.parametrize('input_dtype,output_dtype', np_dtypes)
     def test_binary_PyUFunc(self, input_dtype, output_dtype, f=f2, x=0, y=1):
         xs = np.full(10, input_dtype(x), dtype=output_dtype)
+        xs = FA(xs)
         ys = f(xs, xs)[::2]
         assert_allclose(ys, y)
         assert_equal(ys.dtype, output_dtype)
 
     # class to use in testing object method loops
-    class foo:
+    class foo(object):
         def conjugate(self):
             return np.bool_(1)
 
@@ -131,43 +144,48 @@ class TestUfuncGenericLoops:
     # FA ready
     def test_unary_PyUFunc_O_O(self):
         x = np.ones(10, dtype=object)
+        x = FA(x)
         assert_(np.all(np.abs(x) == 1))
 
     # FA ready
     def test_unary_PyUFunc_O_O_method_simple(self, foo=foo):
         x = np.full(10, foo(), dtype=object)
+        x = FA(x)
         assert_(np.all(np.conjugate(x) == True))
 
     # FA ready
     def test_binary_PyUFunc_OO_O(self):
         x = np.ones(10, dtype=object)
+        x = FA(x)
         assert_(np.all(np.add(x, x) == 2))
 
     # FA ready
     def test_binary_PyUFunc_OO_O_method(self, foo=foo):
         x = np.full(10, foo(), dtype=object)
+        x = FA(x)
         assert_(np.all(np.logical_xor(x, x)))
 
     # FA ready
     def test_binary_PyUFunc_On_Om_method(self, foo=foo):
         x = np.full((10, 2, 3), foo(), dtype=object)
+        x = FA(x)
         assert_(np.all(np.logical_xor(x, x)))
 
     # FA NOT applicable
     @pytest.mark.skip("riptable FA does not support complex numbers.")
     def test_python_complex_conjugate(self):
         # The conjugate ufunc should fall back to calling the method:
-        arr = np.array([1+2j, 3-4j], dtype="O")
+        arr = np.array([1 + 2j, 3 - 4j], dtype="O")
         assert isinstance(arr[0], complex)
         res = np.conjugate(arr)
         assert res.dtype == np.dtype("O")
-        assert_array_equal(res, np.array([1-2j, 3+4j], dtype="O"))
+        assert_array_equal(res, np.array([1 - 2j, 3 + 4j], dtype="O"))
 
     @pytest.mark.skip("TODO - Do we support this functionality in riptable?")
     @pytest.mark.parametrize("ufunc", UNARY_OBJECT_UFUNCS)
     def test_unary_PyUFunc_O_O_method_full(self, ufunc):
         """Compare the result of the object loop with non-object one"""
-        val = np.float64(np.pi/4)
+        val = np.float64(np.pi / 4)
 
         class MyFloat(np.float64):
             def __getattr__(self, attr):
@@ -187,44 +205,33 @@ class TestUfuncGenericLoops:
                     ufunc(obj_arr)
             else:
                 res_obj = ufunc(obj_arr)
-                assert_array_almost_equal(res_num.astype("O"), res_obj)
+                assert_array_equal(res_num.astype("O"), res_obj)
 
 
-def _pickleable_module_global():
-    pass
-
-
-class TestUfunc:
+class TestUfunc(object):
     def test_pickle(self):
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
-            assert_(pickle.loads(pickle.dumps(np.sin,
-                                              protocol=proto)) is np.sin)
+            assert_(pickle.loads(pickle.dumps(np.sin, protocol=proto)) is np.sin)
 
             # Check that ufunc not defined in the top level numpy namespace
             # such as numpy.core._rational_tests.test_add can also be pickled
-            res = pickle.loads(pickle.dumps(_rational_tests.test_add,
-                                            protocol=proto))
+            res = pickle.loads(pickle.dumps(_rational_tests.test_add, protocol=proto))
             assert_(res is _rational_tests.test_add)
 
     def test_pickle_withstring(self):
-        astring = (b"cnumpy.core\n_ufunc_reconstruct\np0\n"
-                   b"(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
+        astring = (
+            b"cnumpy.core\n_ufunc_reconstruct\np0\n"
+            b"(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n."
+        )
         assert_(pickle.loads(astring) is np.cos)
-
-    def test_pickle_name_is_qualname(self):
-        # This tests that a simplification of our ufunc pickle code will
-        # lead to allowing qualnames as names.  Future ufuncs should
-        # possible add a specific qualname, or a hook into pickling instead
-        # (dask+numba may benefit).
-        _pickleable_module_global.ufunc = umt._pickleable_module_global_ufunc
-        obj = pickle.loads(pickle.dumps(_pickleable_module_global.ufunc))
-        assert obj is umt._pickleable_module_global_ufunc
 
     # FA ready
     def test_reduceat_shifting_sum(self):
         L = 6
         x = np.arange(L)
+        x = FA(x)
         idx = np.array(list(zip(np.arange(L - 2), np.arange(L - 2) + 2))).ravel()
+        idx = FA(idx)
         assert_array_equal(np.add.reduceat(x, idx)[::2], [1, 3, 5, 7])
 
     def test_all_ufunc(self):
@@ -313,15 +320,14 @@ class TestUfunc:
     # from include/numpy/ufuncobject.h
     size_inferred = 2
     can_ignore = 4
-    
+
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature0(self):
         # the arguments to test_signature are: nin, nout, core_signature
-        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, "(i),(i)->()")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(2, 1, "(i),(i)->()")
         assert_equal(enabled, 1)
-        assert_equal(num_dims, (1,  1,  0))
+        assert_equal(num_dims, (1, 1, 0))
         assert_equal(ixs, (0, 0))
         assert_equal(flags, (self.size_inferred,))
         assert_equal(sizes, (-1,))
@@ -330,10 +336,9 @@ class TestUfunc:
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature1(self):
         # empty core signature; treat as plain ufunc (with trivial core)
-        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, "(),()->()")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(2, 1, "(),()->()")
         assert_equal(enabled, 0)
-        assert_equal(num_dims, (0,  0,  0))
+        assert_equal(num_dims, (0, 0, 0))
         assert_equal(ixs, ())
         assert_equal(flags, ())
         assert_equal(sizes, ())
@@ -343,22 +348,24 @@ class TestUfunc:
     def test_signature2(self):
         # more complicated names for variables
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, "(i1,i2),(J_1)->(_kAB)")
+            2, 1, "(i1,i2),(J_1)->(_kAB)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 1))
         assert_equal(ixs, (0, 1, 2, 3))
-        assert_equal(flags, (self.size_inferred,)*4)
+        assert_equal(flags, (self.size_inferred,) * 4)
         assert_equal(sizes, (-1, -1, -1, -1))
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature3(self):
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, u"(i1, i12),   (J_1)->(i12, i2)")
+            2, 1, u"(i1, i12),   (J_1)->(i12, i2)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 1, 2))
         assert_equal(ixs, (0, 1, 2, 1, 3))
-        assert_equal(flags, (self.size_inferred,)*4)
+        assert_equal(flags, (self.size_inferred,) * 4)
         assert_equal(sizes, (-1, -1, -1, -1))
 
     # FA NOT applicable
@@ -366,11 +373,12 @@ class TestUfunc:
     def test_signature4(self):
         # matrix_multiply signature from _umath_tests
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, "(n,k),(k,m)->(n,m)")
+            2, 1, "(n,k),(k,m)->(n,m)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 2, 2))
         assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(flags, (self.size_inferred,)*3)
+        assert_equal(flags, (self.size_inferred,) * 3)
         assert_equal(sizes, (-1, -1, -1))
 
     # FA NOT applicable
@@ -378,20 +386,25 @@ class TestUfunc:
     def test_signature5(self):
         # matmul signature from _umath_tests
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            2, 1, "(n?,k),(k,m?)->(n?,m?)")
+            2, 1, "(n?,k),(k,m?)->(n?,m?)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (2, 2, 2))
         assert_equal(ixs, (0, 1, 1, 2, 0, 2))
-        assert_equal(flags, (self.size_inferred | self.can_ignore,
-                             self.size_inferred,
-                             self.size_inferred | self.can_ignore))
+        assert_equal(
+            flags,
+            (
+                self.size_inferred | self.can_ignore,
+                self.size_inferred,
+                self.size_inferred | self.can_ignore,
+            ),
+        )
         assert_equal(sizes, (-1, -1, -1))
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature6(self):
-        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            1, 1, "(3)->()")
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(1, 1, "(3)->()")
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1, 0))
         assert_equal(ixs, (0,))
@@ -402,7 +415,8 @@ class TestUfunc:
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature7(self):
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            3, 1, "(3),(03,3),(n)->(9)")
+            3, 1, "(3),(03,3),(n)->(9)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1, 2, 1, 1))
         assert_equal(ixs, (0, 0, 0, 1, 2))
@@ -413,7 +427,8 @@ class TestUfunc:
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_signature8(self):
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
-            3, 1, "(3?),(3?,3?),(n)->(9)")
+            3, 1, "(3?),(3?,3?),(n)->(9)"
+        )
         assert_equal(enabled, 1)
         assert_equal(num_dims, (1, 2, 1, 1))
         assert_equal(ixs, (0, 0, 0, 1, 2))
@@ -451,135 +466,32 @@ class TestUfunc:
 
     # FA ready
     def test_forced_sig(self):
-        a = 0.5*np.arange(3, dtype='f8')
+        a = 0.5 * np.arange(3, dtype='f8')
+        a = FA(a)
         assert_equal(np.add(a, 0.5), [0.5, 1, 1.5])
-        with pytest.warns(DeprecationWarning):
-            assert_equal(np.add(a, 0.5, sig='i', casting='unsafe'), [0, 0, 1])
+        assert_equal(np.add(a, 0.5, sig='i', casting='unsafe'), [0, 0, 1])
         assert_equal(np.add(a, 0.5, sig='ii->i', casting='unsafe'), [0, 0, 1])
-        with pytest.warns(DeprecationWarning):
-            assert_equal(np.add(a, 0.5, sig=('i4',), casting='unsafe'),
-                         [0, 0, 1])
-        assert_equal(np.add(a, 0.5, sig=('i4', 'i4', 'i4'),
-                                            casting='unsafe'), [0, 0, 1])
+        assert_equal(np.add(a, 0.5, sig=('i4',), casting='unsafe'), [0, 0, 1])
+        assert_equal(
+            np.add(a, 0.5, sig=('i4', 'i4', 'i4'), casting='unsafe'), [0, 0, 1]
+        )
 
         b = np.zeros((3,), dtype='f8')
+        b = FA(b)
         np.add(a, 0.5, out=b)
         assert_equal(b, [0.5, 1, 1.5])
         b[:] = 0
-        with pytest.warns(DeprecationWarning):
-            np.add(a, 0.5, sig='i', out=b, casting='unsafe')
+        np.add(a, 0.5, sig='i', out=b, casting='unsafe')
         assert_equal(b, [0, 0, 1])
         b[:] = 0
         np.add(a, 0.5, sig='ii->i', out=b, casting='unsafe')
         assert_equal(b, [0, 0, 1])
         b[:] = 0
-        with pytest.warns(DeprecationWarning):
-            np.add(a, 0.5, sig=('i4',), out=b, casting='unsafe')
+        np.add(a, 0.5, sig=('i4',), out=b, casting='unsafe')
         assert_equal(b, [0, 0, 1])
         b[:] = 0
         np.add(a, 0.5, sig=('i4', 'i4', 'i4'), out=b, casting='unsafe')
         assert_equal(b, [0, 0, 1])
-
-    def test_signature_all_None(self):
-        # signature all None, is an acceptable alternative (since 1.21)
-        # to not providing a signature.
-        res1 = np.add([3], [4], sig=(None, None, None))
-        res2 = np.add([3], [4])
-        assert_array_equal(res1, res2)
-        res1 = np.maximum([3], [4], sig=(None, None, None))
-        res2 = np.maximum([3], [4])
-        assert_array_equal(res1, res2)
-
-        with pytest.raises(TypeError):
-            # special case, that would be deprecated anyway, so errors:
-            np.add(3, 4, signature=(None,))
-
-    def test_signature_dtype_type(self):
-        # Since that will be the normal behaviour (past NumPy 1.21)
-        # we do support the types already:
-        float_dtype = type(np.dtype(np.float64))
-        np.add(3, 4, signature=(float_dtype, float_dtype, None))
-
-    @pytest.mark.parametrize("casting", ["unsafe", "same_kind", "safe"])
-    def test_partial_signature_mismatch(self, casting):
-        # If the second argument matches already, no need to specify it:
-        res = np.ldexp(np.float32(1.), np.int_(2), dtype="d")
-        assert res.dtype == "d"
-        res = np.ldexp(np.float32(1.), np.int_(2), signature=(None, None, "d"))
-        assert res.dtype == "d"
-
-        # ldexp only has a loop for long input as second argument, overriding
-        # the output cannot help with that (no matter the casting)
-        with pytest.raises(TypeError):
-            np.ldexp(1., np.uint64(3), dtype="d")
-        with pytest.raises(TypeError):
-            np.ldexp(1., np.uint64(3), signature=(None, None, "d"))
-
-    def test_use_output_signature_for_all_arguments(self):
-        # Test that providing only `dtype=` or `signature=(None, None, dtype)`
-        # is sufficient if falling back to a homogeneous signature works.
-        # In this case, the `intp, intp -> intp` loop is chosen.
-        res = np.power(1.5, 2.8, dtype=np.intp, casting="unsafe")
-        assert res == 1  # the cast happens first.
-        res = np.power(1.5, 2.8, signature=(None, None, np.intp),
-                       casting="unsafe")
-        assert res == 1
-        with pytest.raises(TypeError):
-            # the unsafe casting would normally cause errors though:
-            np.power(1.5, 2.8, dtype=np.intp)
-
-    def test_signature_errors(self):
-        with pytest.raises(TypeError,
-                    match="the signature object to ufunc must be a string or"):
-            np.add(3, 4, signature=123.)  # neither a string nor a tuple
-
-        with pytest.raises(ValueError):
-            # bad symbols that do not translate to dtypes
-            np.add(3, 4, signature="%^->#")
-
-        with pytest.raises(ValueError):
-            np.add(3, 4, signature=b"ii-i")  # incomplete and byte string
-
-        with pytest.raises(ValueError):
-            np.add(3, 4, signature="ii>i")  # incomplete string
-
-        with pytest.raises(ValueError):
-            np.add(3, 4, signature=(None, "f8"))  # bad length
-
-        with pytest.raises(UnicodeDecodeError):
-            np.add(3, 4, signature=b"\xff\xff->i")
-
-    def test_forced_dtype_times(self):
-        # Signatures only set the type numbers (not the actual loop dtypes)
-        # so using `M` in a signature/dtype should generally work:
-        a = np.array(['2010-01-02', '1999-03-14', '1833-03'], dtype='>M8[D]')
-        np.maximum(a, a, dtype="M")
-        np.maximum.reduce(a, dtype="M")
-
-        arr = np.arange(10, dtype="m8[s]")
-        np.add(arr, arr, dtype="m")
-        np.maximum(arr, arr, dtype="m")
-
-    def test_forced_dtype_warning(self):
-        # does not warn (test relies on bad pickling behaviour, simply remove
-        # it if the `assert int64 is not int64_2` should start failing.
-        int64 = np.dtype("int64")
-        int64_2 = pickle.loads(pickle.dumps(int64))
-        assert int64 is not int64_2
-        np.add(3, 4, dtype=int64_2)
-
-        arr = np.arange(10, dtype="m8[s]")
-        msg = "The `dtype` and `signature` arguments to ufuncs only select the"
-        with pytest.raises(TypeError, match=msg):
-            np.add(3, 5, dtype=int64.newbyteorder())
-        with pytest.raises(TypeError, match=msg):
-            np.add(3, 5, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.add(arr, arr, dtype="m8[ns]")  # never preserved the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.maximum(arr, arr, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.maximum.reduce(arr, dtype="m8[ns]")  # never preserved the "ns"
 
     # FA NOT support
     # TODO: FA support
@@ -599,9 +511,9 @@ class TestUfunc:
 
                 # Check with no output type specified
                 if tc in 'FDG':
-                    tgt = complex(x)/complex(y)
+                    tgt = complex(x) / complex(y)
                 else:
-                    tgt = float(x)/float(y)
+                    tgt = float(x) / float(y)
 
                 res = np.true_divide(x, y)
                 rtol = max(np.finfo(res).resolution, 1e-15)
@@ -610,7 +522,7 @@ class TestUfunc:
                 if tc in 'bhilqBHILQ':
                     assert_(res.dtype.name == 'float64')
                 else:
-                    assert_(res.dtype.name == dt.name )
+                    assert_(res.dtype.name == dt.name)
 
                 # Check with output type specified.  This also checks for the
                 # incorrect casts in issue gh-3484 because the unary '-' does
@@ -627,7 +539,7 @@ class TestUfunc:
                         # Casting complex to float is not allowed
                         assert_raises(TypeError, np.true_divide, x, y, dtype=dtout)
                     else:
-                        tgt = float(x)/float(y)
+                        tgt = float(x) / float(y)
                         rtol = max(np.finfo(dtout).resolution, 1e-15)
                         atol = max(np.finfo(dtout).tiny, 3e-308)
                         # Some test values result in invalid for float16.
@@ -640,7 +552,7 @@ class TestUfunc:
 
                 for tcout in 'FDG':
                     dtout = np.dtype(tcout)
-                    tgt = complex(x)/complex(y)
+                    tgt = complex(x) / complex(y)
                     rtol = max(np.finfo(dtout).resolution, 1e-15)
                     atol = max(np.finfo(dtout).tiny, 3e-308)
                     res = np.true_divide(x, y, dtype=dtout)
@@ -661,18 +573,20 @@ class TestUfunc:
     # FA ready
     def test_sum_stability(self):
         a = np.ones(500, dtype=np.float32)
-        assert_almost_equal((a / 10.).sum() - a.size / 10., 0, 4)
+        a = FA(a)
+        assert_almost_equal((a / 10.0).sum() - a.size / 10.0, 0, 4)
 
         a = np.ones(500, dtype=np.float64)
-        assert_almost_equal((a / 10.).sum() - a.size / 10., 0, 13)
+        a = FA(a)
+        assert_almost_equal((a / 10.0).sum() - a.size / 10.0, 0, 13)
 
     # FA ready
     def test_sum(self):
         for dt in (int, np.float16, np.float32, np.float64, np.longdouble):
-            for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127,
-                      128, 1024, 1235):
+            for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127, 128, 1024, 1235):
                 tgt = dt(v * (v + 1) / 2)
                 d = np.arange(1, v + 1, dtype=dt)
+                d = FA(d)
 
                 # warning if sum overflows, which it does in float16
                 overflow = not np.isfinite(tgt)
@@ -686,25 +600,25 @@ class TestUfunc:
                     assert_equal(len(w), 2 * overflow)
 
             d = np.ones(500, dtype=dt)
-            assert_almost_equal(np.sum(d[::2]), 250.)
-            assert_almost_equal(np.sum(d[1::2]), 250.)
-            assert_almost_equal(np.sum(d[::3]), 167.)
-            assert_almost_equal(np.sum(d[1::3]), 167.)
-            assert_almost_equal(np.sum(d[::-2]), 250.)
-            assert_almost_equal(np.sum(d[-1::-2]), 250.)
-            assert_almost_equal(np.sum(d[::-3]), 167.)
-            assert_almost_equal(np.sum(d[-1::-3]), 167.)
+            d = FA(d)
+            assert_almost_equal(np.sum(d[::2]), 250.0)
+            assert_almost_equal(np.sum(d[1::2]), 250.0)
+            assert_almost_equal(np.sum(d[::3]), 167.0)
+            assert_almost_equal(np.sum(d[1::3]), 167.0)
+            assert_almost_equal(np.sum(d[::-2]), 250.0)
+            assert_almost_equal(np.sum(d[-1::-2]), 250.0)
+            assert_almost_equal(np.sum(d[::-3]), 167.0)
+            assert_almost_equal(np.sum(d[-1::-3]), 167.0)
             # sum with first reduction entry != 0
             d = np.ones((1,), dtype=dt)
             d += d
-            assert_almost_equal(d, 2.)
+            assert_almost_equal(d, 2.0)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_sum_complex(self):
         for dt in (np.complex64, np.complex128, np.clongdouble):
-            for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127,
-                      128, 1024, 1235):
+            for v in (0, 1, 2, 7, 8, 9, 15, 16, 19, 127, 128, 1024, 1235):
                 tgt = dt(v * (v + 1) / 2) - dt((v * (v + 1) / 2) * 1j)
                 d = np.empty(v, dtype=dt)
                 d.real = np.arange(1, v + 1)
@@ -713,18 +627,18 @@ class TestUfunc:
                 assert_almost_equal(np.sum(d[::-1]), tgt)
 
             d = np.ones(500, dtype=dt) + 1j
-            assert_almost_equal(np.sum(d[::2]), 250. + 250j)
-            assert_almost_equal(np.sum(d[1::2]), 250. + 250j)
-            assert_almost_equal(np.sum(d[::3]), 167. + 167j)
-            assert_almost_equal(np.sum(d[1::3]), 167. + 167j)
-            assert_almost_equal(np.sum(d[::-2]), 250. + 250j)
-            assert_almost_equal(np.sum(d[-1::-2]), 250. + 250j)
-            assert_almost_equal(np.sum(d[::-3]), 167. + 167j)
-            assert_almost_equal(np.sum(d[-1::-3]), 167. + 167j)
+            assert_almost_equal(np.sum(d[::2]), 250.0 + 250j)
+            assert_almost_equal(np.sum(d[1::2]), 250.0 + 250j)
+            assert_almost_equal(np.sum(d[::3]), 167.0 + 167j)
+            assert_almost_equal(np.sum(d[1::3]), 167.0 + 167j)
+            assert_almost_equal(np.sum(d[::-2]), 250.0 + 250j)
+            assert_almost_equal(np.sum(d[-1::-2]), 250.0 + 250j)
+            assert_almost_equal(np.sum(d[::-3]), 167.0 + 167j)
+            assert_almost_equal(np.sum(d[-1::-3]), 167.0 + 167j)
             # sum with first reduction entry != 0
             d = np.ones((1,), dtype=dt) + 1j
             d += d
-            assert_almost_equal(d, 2. + 2j)
+            assert_almost_equal(d, 2.0 + 2j)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -736,48 +650,65 @@ class TestUfunc:
         assert_almost_equal(np.sum([0.2], initial=0.1), 0.3)
 
         # Multiple non-adjacent axes
-        assert_equal(np.sum(np.ones((2, 3, 5), dtype=np.int64), axis=(0, 2), initial=2),
-                     [12, 12, 12])
+        assert_equal(
+            np.sum(np.ones((2, 3, 5), dtype=np.int64), axis=(0, 2), initial=2),
+            [12, 12, 12],
+        )
 
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
     def test_sum_where(self):
         # More extensive tests done in test_reduction_with_where.
-        assert_equal(np.sum([[1., 2.], [3., 4.]], where=[True, False]), 4.)
-        assert_equal(np.sum([[1., 2.], [3., 4.]], axis=0, initial=5.,
-                            where=[True, False]), [9., 5.])
+        assert_equal(np.sum([[1.0, 2.0], [3.0, 4.0]], where=[True, False]), 4.0)
+        assert_equal(
+            np.sum([[1.0, 2.0], [3.0, 4.0]], axis=0, initial=5.0, where=[True, False]),
+            [9.0, 5.0],
+        )
 
     # FA ready
     def test_inner1d(self):
         a = np.arange(6).reshape((2, 3))
-        assert_array_equal(umt.inner1d(a, a), np.sum(a*a, axis=-1))
+        a = FA(a)
+        assert_array_equal(umt.inner1d(a, a), np.sum(a * a, axis=-1))
         a = np.arange(6)
-        assert_array_equal(umt.inner1d(a, a), np.sum(a*a))
+        a = FA(a)
+        assert_array_equal(umt.inner1d(a, a), np.sum(a * a))
 
     # FA ready
     def test_broadcast(self):
         msg = "broadcast"
         a = np.arange(4).reshape((2, 1, 2))
+        a = FA(a)
         b = np.arange(4).reshape((1, 2, 2))
-        assert_array_equal(umt.inner1d(a, b), np.sum(a*b, axis=-1), err_msg=msg)
+        b = FA(b)
+        assert_array_equal(umt.inner1d(a, b), np.sum(a * b, axis=-1), err_msg=msg)
         msg = "extend & broadcast loop dimensions"
         b = np.arange(4).reshape((2, 2))
-        assert_array_equal(umt.inner1d(a, b), np.sum(a*b, axis=-1), err_msg=msg)
+        b = FA(b)
+        assert_array_equal(umt.inner1d(a, b), np.sum(a * b, axis=-1), err_msg=msg)
         # Broadcast in core dimensions should fail
         a = np.arange(8).reshape((4, 2))
+        a = FA(a)
         b = np.arange(4).reshape((4, 1))
+        b = FA(b)
         assert_raises(ValueError, umt.inner1d, a, b)
         # Extend core dimensions should fail
         a = np.arange(8).reshape((4, 2))
+        a = FA(a)
         b = np.array(7)
+        b = FA(b)
         assert_raises(ValueError, umt.inner1d, a, b)
         # Broadcast should fail
         a = np.arange(2).reshape((2, 1, 1))
+        a = FA(a)
         b = np.arange(3).reshape((3, 1, 1))
+        b = FA(b)
         assert_raises(ValueError, umt.inner1d, a, b)
 
         # Writing to a broadcasted array with overlap should warn, gh-2705
         a = np.arange(2)
+        a = FA(a)
         b = np.arange(4).reshape((2, 2))
+        b = FA(b)
         u, v = np.broadcast_arrays(a, b)
         assert_equal(u.strides[0], 0)
         x = u + v
@@ -787,61 +718,40 @@ class TestUfunc:
             assert_equal(len(w), 1)
             assert_(x[0, 0] != u[0, 0])
 
-        # Output reduction should not be allowed.
-        # See gh-15139
-        a = np.arange(6).reshape(3, 2)
-        b = np.ones(2)
-        out = np.empty(())
-        assert_raises(ValueError, umt.inner1d, a, b, out)
-        out2 = np.empty(3)
-        c = umt.inner1d(a, b, out2)
-        assert_(c is out2)
-
-    def test_out_broadcasts(self):
-        # For ufuncs and gufuncs (not for reductions), we currently allow
-        # the output to cause broadcasting of the input arrays.
-        # both along dimensions with shape 1 and dimensions which do not
-        # exist at all in the inputs.
-        arr = np.arange(3).reshape(1, 3)
-        out = np.empty((5, 4, 3))
-        np.add(arr, arr, out=out)
-        assert (out == np.arange(3) * 2).all()
-
-        # The same holds for gufuncs (gh-16484)
-        umt.inner1d(arr, arr, out=out)
-        # the result would be just a scalar `5`, but is broadcast fully:
-        assert (out == 5).all()
-
     # FA ready
     def test_type_cast(self):
         msg = "type cast"
         a = np.arange(6, dtype='short').reshape((2, 3))
-        assert_array_equal(umt.inner1d(a, a), np.sum(a*a, axis=-1),
-                           err_msg=msg)
+        a = FA(a)
+        assert_array_equal(umt.inner1d(a, a), np.sum(a * a, axis=-1), err_msg=msg)
         msg = "type cast on one argument"
         a = np.arange(6).reshape((2, 3))
+        a = FA(a)
         b = a + 0.1
-        assert_array_almost_equal(umt.inner1d(a, b), np.sum(a*b, axis=-1),
-                                  err_msg=msg)
+        assert_array_almost_equal(
+            umt.inner1d(a, b), np.sum(a * b, axis=-1), err_msg=msg
+        )
 
     # FA ready
     def test_endian(self):
         msg = "big endian"
         a = np.arange(6, dtype='>i4').reshape((2, 3))
-        assert_array_equal(umt.inner1d(a, a), np.sum(a*a, axis=-1),
-                           err_msg=msg)
+        a = FA(a)
+        assert_array_equal(umt.inner1d(a, a), np.sum(a * a, axis=-1), err_msg=msg)
         msg = "little endian"
         a = np.arange(6, dtype='<i4').reshape((2, 3))
-        assert_array_equal(umt.inner1d(a, a), np.sum(a*a, axis=-1),
-                           err_msg=msg)
+        a = FA(a)
+        assert_array_equal(umt.inner1d(a, a), np.sum(a * a, axis=-1), err_msg=msg)
 
         # Output should always be native-endian
         Ba = np.arange(1, dtype='>f8')
+        Ba = FA(Ba)
         La = np.arange(1, dtype='<f8')
-        assert_equal((Ba+Ba).dtype, np.dtype('f8'))
-        assert_equal((Ba+La).dtype, np.dtype('f8'))
-        assert_equal((La+Ba).dtype, np.dtype('f8'))
-        assert_equal((La+La).dtype, np.dtype('f8'))
+        La = FA(La)
+        assert_equal((Ba + Ba).dtype, np.dtype('f8'))
+        assert_equal((Ba + La).dtype, np.dtype('f8'))
+        assert_equal((La + Ba).dtype, np.dtype('f8'))
+        assert_equal((La + La).dtype, np.dtype('f8'))
 
         assert_equal(np.absolute(La).dtype, np.dtype('f8'))
         assert_equal(np.absolute(Ba).dtype, np.dtype('f8'))
@@ -853,18 +763,18 @@ class TestUfunc:
     def test_incontiguous_array(self):
         msg = "incontiguous memory layout of array"
         x = np.arange(64).reshape((2, 2, 2, 2, 2, 2))
-        a = x[:, 0,:, 0,:, 0]
-        b = x[:, 1,:, 1,:, 1]
+        a = x[:, 0, :, 0, :, 0]
+        b = x[:, 1, :, 1, :, 1]
         a[0, 0, 0] = -1
         msg2 = "make sure it references to the original array"
         assert_equal(x[0, 0, 0, 0, 0, 0], -1, err_msg=msg2)
-        assert_array_equal(umt.inner1d(a, b), np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(umt.inner1d(a, b), np.sum(a * b, axis=-1), err_msg=msg)
         x = np.arange(24).reshape(2, 3, 4)
         a = x.T
         b = x.T
         a[0, 0, 0] = -1
         assert_equal(x[0, 0, 0], -1, err_msg=msg2)
-        assert_array_equal(umt.inner1d(a, b), np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(umt.inner1d(a, b), np.sum(a * b, axis=-1), err_msg=msg)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -874,34 +784,34 @@ class TestUfunc:
         b = np.arange(4).reshape((2, 1, 2)) + 1
         c = np.zeros((2, 3), dtype='int')
         umt.inner1d(a, b, c)
-        assert_array_equal(c, np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c, np.sum(a * b, axis=-1), err_msg=msg)
         c[:] = -1
         umt.inner1d(a, b, out=c)
-        assert_array_equal(c, np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c, np.sum(a * b, axis=-1), err_msg=msg)
 
         msg = "output argument with type cast"
         c = np.zeros((2, 3), dtype='int16')
         umt.inner1d(a, b, c)
-        assert_array_equal(c, np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c, np.sum(a * b, axis=-1), err_msg=msg)
         c[:] = -1
         umt.inner1d(a, b, out=c)
-        assert_array_equal(c, np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c, np.sum(a * b, axis=-1), err_msg=msg)
 
         msg = "output argument with incontiguous layout"
         c = np.zeros((2, 3, 4), dtype='int16')
         umt.inner1d(a, b, c[..., 0])
-        assert_array_equal(c[..., 0], np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c[..., 0], np.sum(a * b, axis=-1), err_msg=msg)
         c[:] = -1
         umt.inner1d(a, b, out=c[..., 0])
-        assert_array_equal(c[..., 0], np.sum(a*b, axis=-1), err_msg=msg)
+        assert_array_equal(c[..., 0], np.sum(a * b, axis=-1), err_msg=msg)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_axes_argument(self):
         # inner1d signature: '(i),(i)->()'
         inner1d = umt.inner1d
-        a = np.arange(27.).reshape((3, 3, 3))
-        b = np.arange(10., 19.).reshape((3, 1, 3))
+        a = np.arange(27.0).reshape((3, 3, 3))
+        b = np.arange(10.0, 19.0).reshape((3, 1, 3))
         # basic tests on inputs (outputs tested below with matrix_multiply).
         c = inner1d(a, b)
         assert_array_equal(c, (a * b).sum(-1))
@@ -958,8 +868,7 @@ class TestUfunc:
         assert_array_equal(c, np.matmul(a, b))
         # swap some axes.
         c = mm(a, b, axes=[(0, -1), (1, 2), (-2, -1)])
-        assert_array_equal(c, np.matmul(a.transpose(1, 0, 2),
-                                        b.transpose(0, 3, 1, 2)))
+        assert_array_equal(c, np.matmul(a.transpose(1, 0, 2), b.transpose(0, 3, 1, 2)))
         # Default with output array.
         c = np.empty((2, 2, 3, 1))
         d = mm(a, b, out=c, axes=[(1, 2), (2, 3), (2, 3)])
@@ -982,10 +891,8 @@ class TestUfunc:
         # list should contain tuples for multiple axes
         assert_raises(TypeError, mm, a, b, axes=[-1, -1, -1])
         assert_raises(TypeError, mm, a, b, axes=[(-2, -1), (-2, -1), -1])
-        assert_raises(TypeError,
-                      mm, a, b, axes=[[-2, -1], [-2, -1], [-2, -1]])
-        assert_raises(TypeError,
-                      mm, a, b, axes=[(-2, -1), (-2, -1), [-2, -1]])
+        assert_raises(TypeError, mm, a, b, axes=[[-2, -1], [-2, -1], [-2, -1]])
+        assert_raises(TypeError, mm, a, b, axes=[(-2, -1), (-2, -1), [-2, -1]])
         assert_raises(TypeError, mm, a, b, axes=[(-2, -1), (-2, -1), None])
         # tuples should not have duplicated values
         assert_raises(ValueError, mm, a, b, axes=[(-2, -1), (-2, -1), (-2, -2)])
@@ -996,7 +903,7 @@ class TestUfunc:
         assert_raises(ValueError, mm, z[1], z, axes=[0, 1])
         assert_raises(ValueError, mm, z, z, out=z[0], axes=[0, 1])
         # Regular ufuncs should not accept axes.
-        assert_raises(TypeError, np.add, 1., 1., axes=[0])
+        assert_raises(TypeError, np.add, 1.0, 1.0, axes=[0])
         # should be able to deal with bad unrelated kwargs.
         assert_raises(TypeError, mm, z, z, axes=[0, 1], parrot=True)
 
@@ -1005,8 +912,8 @@ class TestUfunc:
     def test_axis_argument(self):
         # inner1d signature: '(i),(i)->()'
         inner1d = umt.inner1d
-        a = np.arange(27.).reshape((3, 3, 3))
-        b = np.arange(10., 19.).reshape((3, 1, 3))
+        a = np.arange(27.0).reshape((3, 3, 3))
+        b = np.arange(10.0, 19.0).reshape((3, 1, 3))
         c = inner1d(a, b)
         assert_array_equal(c, (a * b).sum(-1))
         c = inner1d(a, b, axis=-1)
@@ -1021,8 +928,7 @@ class TestUfunc:
         a = np.arange(6).reshape((2, 3))
         b = np.arange(10, 16).reshape((2, 3))
         w = np.arange(20, 26).reshape((2, 3))
-        assert_array_equal(umt.innerwt(a, b, w, axis=0),
-                           np.sum(a * b * w, axis=0))
+        assert_array_equal(umt.innerwt(a, b, w, axis=0), np.sum(a * b * w, axis=0))
         assert_array_equal(umt.cumsum(a, axis=0), np.cumsum(a, axis=0))
         assert_array_equal(umt.cumsum(a, axis=-1), np.cumsum(a, axis=-1))
         out = np.empty_like(a)
@@ -1044,15 +950,15 @@ class TestUfunc:
         out = np.empty((1, 2, 3), dtype=a.dtype)
         assert_raises(ValueError, umt.cumsum, a, out=out, axis=0)
         # Regular ufuncs should not accept axis.
-        assert_raises(TypeError, np.add, 1., 1., axis=0)
+        assert_raises(TypeError, np.add, 1.0, 1.0, axis=0)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_keepdims_argument(self):
         # inner1d signature: '(i),(i)->()'
         inner1d = umt.inner1d
-        a = np.arange(27.).reshape((3, 3, 3))
-        b = np.arange(10., 19.).reshape((3, 1, 3))
+        a = np.arange(27.0).reshape((3, 3, 3))
+        b = np.arange(10.0, 19.0).reshape((3, 1, 3))
         c = inner1d(a, b)
         assert_array_equal(c, (a * b).sum(-1))
         c = inner1d(a, b, keepdims=False)
@@ -1083,25 +989,24 @@ class TestUfunc:
         c = inner1d(a, b, axes=[0, 2], keepdims=False)
         assert_array_equal(c, (a.transpose(1, 2, 0) * b).sum(-1))
         c = inner1d(a, b, axes=[0, 2], keepdims=True)
-        assert_array_equal(c, (a.transpose(1, 2, 0) * b).sum(-1,
-                                                             keepdims=True))
+        assert_array_equal(c, (a.transpose(1, 2, 0) * b).sum(-1, keepdims=True))
         c = inner1d(a, b, axes=[0, 2, 2], keepdims=True)
-        assert_array_equal(c, (a.transpose(1, 2, 0) * b).sum(-1,
-                                                             keepdims=True))
+        assert_array_equal(c, (a.transpose(1, 2, 0) * b).sum(-1, keepdims=True))
         c = inner1d(a, b, axes=[0, 2, 0], keepdims=True)
         assert_array_equal(c, (a * b.transpose(2, 0, 1)).sum(0, keepdims=True))
         # Hardly useful, but should work.
         c = inner1d(a, b, axes=[0, 2, 1], keepdims=True)
-        assert_array_equal(c, (a.transpose(1, 0, 2) * b.transpose(0, 2, 1))
-                           .sum(1, keepdims=True))
+        assert_array_equal(
+            c, (a.transpose(1, 0, 2) * b.transpose(0, 2, 1)).sum(1, keepdims=True)
+        )
         # Check with two core dimensions.
-        a = np.eye(3) * np.arange(4.)[:, np.newaxis, np.newaxis]
+        a = np.eye(3) * np.arange(4.0)[:, np.newaxis, np.newaxis]
         expected = uml.det(a)
         c = uml.det(a, keepdims=False)
         assert_array_equal(c, expected)
         c = uml.det(a, keepdims=True)
         assert_array_equal(c, expected[:, np.newaxis, np.newaxis])
-        a = np.eye(3) * np.arange(4.)[:, np.newaxis, np.newaxis]
+        a = np.eye(3) * np.arange(4.0)[:, np.newaxis, np.newaxis]
         expected_s, expected_l = uml.slogdet(a)
         cs, cl = uml.slogdet(a, keepdims=False)
         assert_array_equal(cs, expected_s)
@@ -1113,10 +1018,14 @@ class TestUfunc:
         a = np.arange(6).reshape((2, 3))
         b = np.arange(10, 16).reshape((2, 3))
         w = np.arange(20, 26).reshape((2, 3))
-        assert_array_equal(umt.innerwt(a, b, w, keepdims=True),
-                           np.sum(a * b * w, axis=-1, keepdims=True))
-        assert_array_equal(umt.innerwt(a, b, w, axis=0, keepdims=True),
-                           np.sum(a * b * w, axis=0, keepdims=True))
+        assert_array_equal(
+            umt.innerwt(a, b, w, keepdims=True),
+            np.sum(a * b * w, axis=-1, keepdims=True),
+        )
+        assert_array_equal(
+            umt.innerwt(a, b, w, axis=0, keepdims=True),
+            np.sum(a * b * w, axis=0, keepdims=True),
+        )
         # Check errors.
         # Not a boolean
         assert_raises(TypeError, inner1d, a, b, keepdims='true')
@@ -1125,7 +1034,7 @@ class TestUfunc:
         assert_raises(TypeError, mm, a, b, keepdims=True)
         assert_raises(TypeError, mm, a, b, keepdims=False)
         # Regular ufuncs should not accept keepdims.
-        assert_raises(TypeError, np.add, 1., 1., keepdims=False)
+        assert_raises(TypeError, np.add, 1.0, 1.0, keepdims=False)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -1133,37 +1042,40 @@ class TestUfunc:
         a = np.arange(6).reshape((2, 3))
         b = np.arange(10, 16).reshape((2, 3))
         w = np.arange(20, 26).reshape((2, 3))
-        assert_array_equal(umt.innerwt(a, b, w), np.sum(a*b*w, axis=-1))
+        assert_array_equal(umt.innerwt(a, b, w), np.sum(a * b * w, axis=-1))
         a = np.arange(100, 124).reshape((2, 3, 4))
         b = np.arange(200, 224).reshape((2, 3, 4))
         w = np.arange(300, 324).reshape((2, 3, 4))
-        assert_array_equal(umt.innerwt(a, b, w), np.sum(a*b*w, axis=-1))
+        assert_array_equal(umt.innerwt(a, b, w), np.sum(a * b * w, axis=-1))
 
     # FA ready
     def test_innerwt_empty(self):
         """Test generalized ufunc with zero-sized operands"""
         a = np.array([], dtype='f8')
+        a = FA(a)
         b = np.array([], dtype='f8')
+        b = FA(b)
         w = np.array([], dtype='f8')
-        assert_array_equal(umt.innerwt(a, b, w), np.sum(a*b*w, axis=-1))
+        w = FA(w)
+        assert_array_equal(umt.innerwt(a, b, w), np.sum(a * b * w, axis=-1))
 
     # TODO: Need to adapt this test for riptable. The obvious changes didn't seem to work
     #       so let's circle back to this (since it's a new test since numpy 1.15.x).
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
     def test_cross1d(self):
         """Test with fixed-sized signature."""
-        a = np.eye(3)
-        assert_array_equal(umt.cross1d(a, a), np.zeros((3, 3)))
+        a = np.eye(
+            3
+        )  # TODO: Change this to rt.eye() once we've implemented the eye() function in riptable.
+        a = FA(a)
+        assert_array_equal(umt.cross1d(a, a), rt.zeros((3, 3)))
         out = np.zeros((3, 3))
         result = umt.cross1d(a[0], a, out)
         assert_(result is out)
-        assert_array_equal(result, np.vstack((np.zeros(3), a[2], -a[1])))
-        assert_raises(ValueError, umt.cross1d, np.eye(4), np.eye(4))
-        assert_raises(ValueError, umt.cross1d, a, np.arange(4.))
-        # Wrong output core dimension.
-        assert_raises(ValueError, umt.cross1d, a, np.arange(3.), np.zeros((3, 4)))
-        # Wrong output broadcast dimension (see gh-15139).
-        assert_raises(ValueError, umt.cross1d, a, np.arange(3.), np.zeros(3))
+        assert_array_equal(result, rt.vstack((rt.zeros(3), a[2], -a[1])))
+        assert_raises(ValueError, umt.cross1d, rt.eye(4), rt.eye(4))
+        assert_raises(ValueError, umt.cross1d, a, rt.arange(4.0))
+        assert_raises(ValueError, umt.cross1d, a, rt.arange(3.0), rt.zeros((3, 4)))
 
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
     def test_can_ignore_signature(self):
@@ -1231,8 +1143,7 @@ class TestUfunc:
         assert_array_equal(out, mm_row_col_array)
         # And check one cannot put missing dimensions back.
         out = np.zeros_like(mm_row_col_vec)
-        assert_raises(ValueError, umt.matrix_multiply, single_vec, single_vec,
-                      out)
+        assert_raises(ValueError, umt.matrix_multiply, single_vec, single_vec, out)
         # But fine for matmul, since it is just a broadcast.
         out = umt.matmul(single_vec, single_vec, out)
         assert_array_equal(out, mm_row_col_vec.squeeze())
@@ -1262,12 +1173,12 @@ class TestUfunc:
             if n == 1:
                 return ([0],)
             ret = ()
-            base = permute_n(n-1)
+            base = permute_n(n - 1)
             for perm in base:
                 for i in range(n):
-                    new = perm + [n-1]
-                    new[n-1] = new[i]
-                    new[i] = n-1
+                    new = perm + [n - 1]
+                    new[n - 1] = new[i]
+                    new[i] = n - 1
                     ret += (new,)
             return ret
 
@@ -1275,17 +1186,17 @@ class TestUfunc:
             if n == 0:
                 return ((),)
             ret = ()
-            base = slice_n(n-1)
+            base = slice_n(n - 1)
             for sl in base:
-                ret += (sl+(slice(None),),)
-                ret += (sl+(slice(0, 1),),)
+                ret += (sl + (slice(None),),)
+                ret += (sl + (slice(0, 1),),)
             return ret
 
         def broadcastable(s1, s2):
             return s1 == s2 or s1 == 1 or s2 == 1
 
         permute_3 = permute_n(3)
-        slice_3 = slice_n(3) + ((slice(None, None, -1),)*3,)
+        slice_3 = slice_n(3) + ((slice(None, None, -1),) * 3,)
 
         ref = True
         for p1 in permute_3:
@@ -1296,23 +1207,30 @@ class TestUfunc:
                         a2 = d2.transpose(p2)[s2]
                         ref = ref and a1.base is not None
                         ref = ref and a2.base is not None
-                        if (a1.shape[-1] == a2.shape[-2] and
-                                broadcastable(a1.shape[0], a2.shape[0])):
+                        if a1.shape[-1] == a2.shape[-2] and broadcastable(
+                            a1.shape[0], a2.shape[0]
+                        ):
                             assert_array_almost_equal(
                                 umt.matrix_multiply(a1, a2),
-                                np.sum(a2[..., np.newaxis].swapaxes(-3, -1) *
-                                       a1[..., np.newaxis,:], axis=-1),
-                                err_msg=msg + ' %s %s' % (str(a1.shape),
-                                                          str(a2.shape)))
+                                np.sum(
+                                    a2[..., np.newaxis].swapaxes(-3, -1)
+                                    * a1[..., np.newaxis, :],
+                                    axis=-1,
+                                ),
+                                err_msg=msg + ' %s %s' % (str(a1.shape), str(a2.shape)),
+                            )
 
         assert_equal(ref, True, err_msg="reference check")
 
     # FA ready
     def test_euclidean_pdist(self):
         a = np.arange(12, dtype=float).reshape(4, 3)
+        a = FA(a)
         out = np.empty((a.shape[0] * (a.shape[0] - 1) // 2,), dtype=a.dtype)
+        out = FA(out)
         umt.euclidean_pdist(a, out)
-        b = np.sqrt(np.sum((a[:, None] - a)**2, axis=-1))
+        b = np.sqrt(np.sum((a[:, None] - a) ** 2, axis=-1))
+        b = FA(b)
         b = b[~np.tri(a.shape[0], dtype=bool)]
         assert_almost_equal(out, b)
         # An output array is required to determine p with signature (n,d)->(p)
@@ -1328,26 +1246,32 @@ class TestUfunc:
     # FA ready
     def test_object_logical(self):
         a = np.array([3, None, True, False, "test", ""], dtype=object)
-        assert_equal(np.logical_or(a, None),
-                        np.array([x or None for x in a], dtype=object))
-        assert_equal(np.logical_or(a, True),
-                        np.array([x or True for x in a], dtype=object))
-        assert_equal(np.logical_or(a, 12),
-                        np.array([x or 12 for x in a], dtype=object))
-        assert_equal(np.logical_or(a, "blah"),
-                        np.array([x or "blah" for x in a], dtype=object))
+        a = FA(a)
+        assert_equal(
+            np.logical_or(a, None), np.array([x or None for x in a], dtype=object)
+        )
+        assert_equal(
+            np.logical_or(a, True), np.array([x or True for x in a], dtype=object)
+        )
+        assert_equal(np.logical_or(a, 12), np.array([x or 12 for x in a], dtype=object))
+        assert_equal(
+            np.logical_or(a, "blah"), np.array([x or "blah" for x in a], dtype=object)
+        )
 
-        assert_equal(np.logical_and(a, None),
-                        np.array([x and None for x in a], dtype=object))
-        assert_equal(np.logical_and(a, True),
-                        np.array([x and True for x in a], dtype=object))
-        assert_equal(np.logical_and(a, 12),
-                        np.array([x and 12 for x in a], dtype=object))
-        assert_equal(np.logical_and(a, "blah"),
-                        np.array([x and "blah" for x in a], dtype=object))
+        assert_equal(
+            np.logical_and(a, None), np.array([x and None for x in a], dtype=object)
+        )
+        assert_equal(
+            np.logical_and(a, True), np.array([x and True for x in a], dtype=object)
+        )
+        assert_equal(
+            np.logical_and(a, 12), np.array([x and 12 for x in a], dtype=object)
+        )
+        assert_equal(
+            np.logical_and(a, "blah"), np.array([x and "blah" for x in a], dtype=object)
+        )
 
-        assert_equal(np.logical_not(a),
-                        np.array([not x for x in a], dtype=object))
+        assert_equal(np.logical_not(a), np.array([not x for x in a], dtype=object))
 
         assert_equal(np.logical_or.reduce(a), 3)
         assert_equal(np.logical_and.reduce(a), None)
@@ -1357,7 +1281,7 @@ class TestUfunc:
         "This test utilizes an operation which is explicitly not supported by FastArray."
     )
     def test_object_comparison(self):
-        class HasComparisons:
+        class HasComparisons(object):
             def __eq__(self, other):
                 return '=='
 
@@ -1367,17 +1291,21 @@ class TestUfunc:
 
         arr1d = np.array([HasComparisons()])
         assert_equal(arr1d == arr1d, np.array([True]))
-        assert_equal(np.equal(arr1d, arr1d), np.array([True]))  # normal behavior is a cast
+        assert_equal(
+            np.equal(arr1d, arr1d), np.array([True])
+        )  # normal behavior is a cast
         assert_equal(np.equal(arr1d, arr1d, dtype=object), np.array(['==']))
 
     # FA ready
     def test_object_array_reduction(self):
         # Reductions on object arrays
         a = np.array(['a', 'b', 'c'], dtype=object)
+        a = FA(a)
         assert_equal(np.sum(a), 'abc')
         assert_equal(np.max(a), 'c')
         assert_equal(np.min(a), 'a')
         a = np.array([True, False, True], dtype=object)
+        a = FA(a)
         assert_equal(np.sum(a), 2)
         assert_equal(np.prod(a), 0)
         assert_equal(np.any(a), True)
@@ -1387,36 +1315,38 @@ class TestUfunc:
         assert_equal(np.array([[1]], dtype=object).sum(), 1)
         assert_equal(np.array([[[1, 2]]], dtype=object).sum((0, 1)), [1, 2])
         assert_equal(np.array([1], dtype=object).sum(initial=1), 2)
-        assert_equal(np.array([[1], [2, 3]], dtype=object)
-                     .sum(initial=[0], where=[False, True]), [0, 2, 3])
+        assert_equal(
+            np.array([[1], [2, 3]], dtype=object).sum(initial=[0], where=[False, True]),
+            [0, 2, 3],
+        )
 
     # FA ready
     def test_object_array_accumulate_inplace(self):
         # Checks that in-place accumulates work, see also gh-7402
         arr = np.ones(4, dtype=object)
+        arr = FA(arr)
         arr[:] = [[1] for i in range(4)]
         # Twice reproduced also for tuples:
         np.add.accumulate(arr, out=arr)
         np.add.accumulate(arr, out=arr)
-        assert_array_equal(arr,
-                           np.array([[1]*i for i in [1, 3, 6, 10]], dtype=object),
-                          )
+        assert_array_equal(arr, np.array([[1] * i for i in [1, 3, 6, 10]]))
 
         # And the same if the axis argument is used
         arr = np.ones((2, 4), dtype=object)
+        arr = FA(arr)
         arr[0, :] = [[2] for i in range(4)]
         np.add.accumulate(arr, out=arr, axis=-1)
         np.add.accumulate(arr, out=arr, axis=-1)
-        assert_array_equal(arr[0, :],
-                           np.array([[2]*i for i in [1, 3, 6, 10]], dtype=object),
-                          )
+        assert_array_equal(arr[0, :], np.array([[2] * i for i in [1, 3, 6, 10]]))
 
     # FA ready
     def test_object_array_reduceat_inplace(self):
         # Checks that in-place reduceats work, see also gh-7465
         arr = np.empty(4, dtype=object)
+        arr = FA(arr)
         arr[:] = [[1] for i in range(4)]
         out = np.empty(4, dtype=object)
+        out = FA(out)
         out[:] = [[1] for i in range(4)]
         np.add.reduceat(arr, np.arange(4), out=arr)
         np.add.reduceat(arr, np.arange(4), out=arr)
@@ -1424,8 +1354,10 @@ class TestUfunc:
 
         # And the same if the axis argument is used
         arr = np.ones((2, 4), dtype=object)
+        arr = FA(arr)
         arr[0, :] = [[2] for i in range(4)]
         out = np.ones((2, 4), dtype=object)
+        out = FA(out)
         out[0, :] = [[2] for i in range(4)]
         np.add.reduceat(arr, np.arange(4), out=arr, axis=-1)
         np.add.reduceat(arr, np.arange(4), out=arr, axis=-1)
@@ -1435,6 +1367,7 @@ class TestUfunc:
     def test_zerosize_reduction(self):
         # Test with default dtype and object dtype
         for a in [[], np.array([], dtype=object)]:
+            a = FA(a)
             assert_equal(np.sum(a), 0)
             assert_equal(np.prod(a), 1)
             assert_equal(np.any(a), False)
@@ -1445,13 +1378,17 @@ class TestUfunc:
     # FA ready
     def test_axis_out_of_bounds(self):
         a = np.array([False, False])
+        a = FA(a)
         assert_raises(np.AxisError, a.all, axis=1)
         a = np.array([False, False])
+        a = FA(a)
         assert_raises(np.AxisError, a.all, axis=-2)
 
         a = np.array([False, False])
+        a = FA(a)
         assert_raises(np.AxisError, a.any, axis=1)
         a = np.array([False, False])
+        a = FA(a)
         assert_raises(np.AxisError, a.any, axis=-2)
 
     # FA NOT applicable
@@ -1481,6 +1418,7 @@ class TestUfunc:
         # assert that 0-d arrays get wrapped
         class MyArray(np.ndarray):
             pass
+
         a = np.array(1).view(MyArray)
         assert_(type(np.any(a)) is MyArray)
 
@@ -1488,13 +1426,18 @@ class TestUfunc:
     def test_casting_out_param(self):
         # Test that it's possible to do casts on output
         a = np.ones((200, 100), np.int64)
+        a = FA(a)
         b = np.ones((200, 100), np.int64)
+        b = FA(b)
         c = np.ones((200, 100), np.float64)
+        c = FA(c)
         np.add(a, b, out=c)
         assert_equal(c, 2)
 
         a = np.zeros(65536)
+        a = FA(a)
         b = np.zeros(65536, dtype=np.float32)
+        b = FA(b)
         np.subtract(a, 0, out=b)
         assert_equal(b, 0)
 
@@ -1502,12 +1445,16 @@ class TestUfunc:
     def test_where_param(self):
         # Test that the where= ufunc parameter works with regular arrays
         a = np.arange(7)
+        a = FA(a)
         b = np.ones(7)
+        b = FA(b)
         c = np.zeros(7)
+        c = FA(c)
         np.add(a, b, out=c, where=(a % 2 == 1))
         assert_equal(c, [0, 2, 0, 4, 0, 6, 0])
 
         a = np.arange(4).reshape(2, 2) + 2
+        a = FA(a)
         np.power(a, [2, 3], out=a, where=[[0, 1], [1, 0]])
         assert_equal(a, [[2, 27], [16, 5]])
         # Broadcasting the where= parameter
@@ -1521,8 +1468,11 @@ class TestUfunc:
 
         # With casting on output
         a = np.ones(10, np.int64)
+        a = FA(a)
         b = np.ones(10, np.int64)
+        b = FA(b)
         c = 1.5 * np.ones(10, np.float64)
+        c = FA(c)
         np.add(a, b, out=c, where=[1, 0, 0, 1, 0, 0, 1, 1, 1, 0])
         assert_equal(c, [2, 1.5, 1.5, 2, 1.5, 1.5, 2, 2, 2, 1.5])
 
@@ -1530,25 +1480,17 @@ class TestUfunc:
     def test_where_param_alloc(self):
         # With casting and allocated output
         a = np.array([1], dtype=np.int64)
+        a = FA(a)
         m = np.array([True], dtype=bool)
+        m = FA(m)
         assert_equal(np.sqrt(a, where=m), [1])
 
         # No casting and allocated output
         a = np.array([1], dtype=np.float64)
+        a = FA(a)
         m = np.array([True], dtype=bool)
+        m = FA(m)
         assert_equal(np.sqrt(a, where=m), [1])
-
-    def test_where_with_broadcasting(self):
-        # See gh-17198
-        a = np.random.random((5000, 4))
-        b = np.random.random((5000, 1))
-
-        where = a > 0.3
-        out = np.full_like(a, 0)
-        np.less(a, b, where=where, out=out)
-        b_where = np.broadcast_to(b, a.shape)[where]
-        assert_array_equal((a[where] < b_where), out[where].astype(bool))
-        assert not out[~where].any()  # outside mask, out remains all 0
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -1562,12 +1504,11 @@ class TestUfunc:
         assert_equal(np.minimum.reduce(a, axis=(0, 1)), [0, 1, 1, 1])
         assert_equal(np.minimum.reduce(a, axis=(0, 2)), [0, 1, 1])
         assert_equal(np.minimum.reduce(a, axis=(1, 2)), [1, 0])
-        assert_equal(np.minimum.reduce(a, axis=0),
-                                    [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=1),
-                                    [[1, 1, 1, 1], [0, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=2),
-                                    [[1, 1, 1], [0, 1, 1]])
+        assert_equal(
+            np.minimum.reduce(a, axis=0), [[0, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]]
+        )
+        assert_equal(np.minimum.reduce(a, axis=1), [[1, 1, 1, 1], [0, 1, 1, 1]])
+        assert_equal(np.minimum.reduce(a, axis=2), [[1, 1, 1], [0, 1, 1]])
         assert_equal(np.minimum.reduce(a, axis=()), a)
 
         a[...] = 1
@@ -1576,12 +1517,11 @@ class TestUfunc:
         assert_equal(np.minimum.reduce(a, axis=(0, 1)), [0, 1, 1, 1])
         assert_equal(np.minimum.reduce(a, axis=(0, 2)), [1, 0, 1])
         assert_equal(np.minimum.reduce(a, axis=(1, 2)), [0, 1])
-        assert_equal(np.minimum.reduce(a, axis=0),
-                                    [[1, 1, 1, 1], [0, 1, 1, 1], [1, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=1),
-                                    [[0, 1, 1, 1], [1, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=2),
-                                    [[1, 0, 1], [1, 1, 1]])
+        assert_equal(
+            np.minimum.reduce(a, axis=0), [[1, 1, 1, 1], [0, 1, 1, 1], [1, 1, 1, 1]]
+        )
+        assert_equal(np.minimum.reduce(a, axis=1), [[0, 1, 1, 1], [1, 1, 1, 1]])
+        assert_equal(np.minimum.reduce(a, axis=2), [[1, 0, 1], [1, 1, 1]])
         assert_equal(np.minimum.reduce(a, axis=()), a)
 
         a[...] = 1
@@ -1590,12 +1530,11 @@ class TestUfunc:
         assert_equal(np.minimum.reduce(a, axis=(0, 1)), [1, 0, 1, 1])
         assert_equal(np.minimum.reduce(a, axis=(0, 2)), [0, 1, 1])
         assert_equal(np.minimum.reduce(a, axis=(1, 2)), [0, 1])
-        assert_equal(np.minimum.reduce(a, axis=0),
-                                    [[1, 0, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=1),
-                                    [[1, 0, 1, 1], [1, 1, 1, 1]])
-        assert_equal(np.minimum.reduce(a, axis=2),
-                                    [[0, 1, 1], [1, 1, 1]])
+        assert_equal(
+            np.minimum.reduce(a, axis=0), [[1, 0, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]]
+        )
+        assert_equal(np.minimum.reduce(a, axis=1), [[1, 0, 1, 1], [1, 1, 1, 1]])
+        assert_equal(np.minimum.reduce(a, axis=2), [[0, 1, 1], [1, 1, 1]])
         assert_equal(np.minimum.reduce(a, axis=()), a)
 
     # FA NOT applicable
@@ -1626,7 +1565,7 @@ class TestUfunc:
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_identityless_reduction_noncontig_unaligned(self):
-        a = np.empty((3*4*5*8 + 1,), dtype='i1')
+        a = np.empty((3 * 4 * 5 * 8 + 1,), dtype='i1')
         a = a[1:].view(dtype='f8')
         a.shape = (3, 4, 5)
         a = a[1:, 1:, 1:]
@@ -1666,13 +1605,16 @@ class TestUfunc:
 
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
     @pytest.mark.parametrize('axis', (0, 1, None))
-    @pytest.mark.parametrize('where', (np.array([False, True, True]),
-                                       np.array([[True], [False], [True]]),
-                                       np.array([[True, False, False],
-                                                 [False, True, False],
-                                                 [False, True, True]])))
+    @pytest.mark.parametrize(
+        'where',
+        (
+            np.array([False, True, True]),
+            np.array([[True], [False], [True]]),
+            np.array([[True, False, False], [False, True, False], [False, True, True]]),
+        ),
+    )
     def test_reduction_with_where(self, axis, where):
-        a = np.arange(9.).reshape(3, 3)
+        a = np.arange(9.0).reshape(3, 3)
         a_copy = a.copy()
         a_check = np.zeros_like(a)
         np.positive(a, out=a_check, where=where)
@@ -1684,13 +1626,13 @@ class TestUfunc:
         assert_array_equal(a, a_copy)
 
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
-    @pytest.mark.parametrize(('axis', 'where'),
-                             ((0, np.array([True, False, True])),
-                              (1, [True, True, False]),
-                              (None, True)))
-    @pytest.mark.parametrize('initial', (-np.inf, 5.))
+    @pytest.mark.parametrize(
+        ('axis', 'where'),
+        ((0, np.array([True, False, True])), (1, [True, True, False]), (None, True)),
+    )
+    @pytest.mark.parametrize('initial', (-np.inf, 5.0))
     def test_reduction_with_where_and_initial(self, axis, where, initial):
-        a = np.arange(9.).reshape(3, 3)
+        a = np.arange(9.0).reshape(3, 3)
         a_copy = a.copy()
         a_check = np.full(a.shape, -np.inf)
         np.positive(a, out=a_check, where=where)
@@ -1699,8 +1641,9 @@ class TestUfunc:
         check = a_check.max(axis, initial=initial)
         assert_equal(res, check)
 
+    @pytest.mark.skip("TODO: Adapt this test for riptable?")
     def test_reduction_where_initial_needed(self):
-        a = np.arange(9.).reshape(3, 3)
+        a = np.arange(9.0).reshape(3, 3)
         m = [False, True, False]
         assert_raises(ValueError, np.maximum.reduce, a, where=m)
 
@@ -1749,9 +1692,9 @@ class TestUfunc:
             expect(func, np.zeros((n // 2, m, n // 2)), axis=1)
             expect(func, np.zeros((n, m // 2, m // 2)), axis=(1, 2))
             expect(func, np.zeros((m // 2, n, m // 2)), axis=(0, 2))
-            expect(func, np.zeros((m // 3, m // 3, m // 3,
-                                  n // 2, n // 2)),
-                                 axis=(0, 1, 2))
+            expect(
+                func, np.zeros((m // 3, m // 3, m // 3, n // 2, n // 2)), axis=(0, 1, 2)
+            )
             # Check what happens if the inner (resp. outer) dimensions are a
             # mix of zero and non-zero:
             expect(func, np.zeros((10, m, n)), axis=(0, 1))
@@ -1794,10 +1737,11 @@ class TestUfunc:
         # default and an exception is raised instead of a warning.
         # when 'same_kind' is not satisfied.
         a = np.array([1, 2, 3], dtype=int)
+        a = FA(a)
         # Non-in-place addition is fine
-        assert_array_equal(assert_no_warnings(np.add, a, 1.1),
-                           [2.1, 3.1, 4.1])
+        assert_array_equal(assert_no_warnings(np.add, a, 1.1), [2.1, 3.1, 4.1])
         # TODO: FA should raise TypeError?
+        a = np.array([1, 2, 3], dtype=int)
         assert_raises(TypeError, np.add, a, 1.1, out=a)
 
         def add_inplace(a, b):
@@ -1806,6 +1750,7 @@ class TestUfunc:
         # TODO: FA should raise TypeError?
         assert_raises(TypeError, add_inplace, a, 1.1)
         # Make sure that explicitly overriding the exception is allowed:
+        a = FA(a)
         assert_no_warnings(np.add, a, 1.1, out=a, casting="unsafe")
         assert_array_equal(a, [2, 3, 4])
 
@@ -1814,13 +1759,17 @@ class TestUfunc:
         # Test ufunc with built in input types and custom output type
 
         a = np.array([0, 1, 2], dtype='i8')
+        a = FA(a)
         b = np.array([0, 1, 2], dtype='i8')
+        b = FA(b)
         c = np.empty(3, dtype=_rational_tests.rational)
+        c = FA(c)
 
         # Output must be specified so numpy knows what
         # ufunc signature to look for
         result = _rational_tests.test_add(a, b, c)
         target = np.array([0, 2, 4], dtype=_rational_tests.rational)
+        target = FA(target)
         assert_equal(result, target)
 
         # no output type should raise TypeError
@@ -1830,12 +1779,20 @@ class TestUfunc:
     # FA ready
     def test_operand_flags(self):
         a = np.arange(16, dtype='l').reshape(4, 4)
+        a = FA(a)
         b = np.arange(9, dtype='l').reshape(3, 3)
+        b = FA(b)
         opflag_tests.inplace_add(a[:-1, :-1], b)
-        assert_equal(a, np.array([[0, 2, 4, 3], [7, 9, 11, 7],
-            [14, 16, 18, 11], [12, 13, 14, 15]], dtype='l'))
+        assert_equal(
+            a,
+            np.array(
+                [[0, 2, 4, 3], [7, 9, 11, 7], [14, 16, 18, 11], [12, 13, 14, 15]],
+                dtype='l',
+            ),
+        )
 
         a = np.array(0)
+        a = FA(a)
         opflag_tests.inplace_add(a, 3)
         assert_equal(a, 3)
         opflag_tests.inplace_add(a, [3, 4])
@@ -1846,7 +1803,9 @@ class TestUfunc:
         import numpy.core._struct_ufunc_tests as struct_ufunc
 
         a = np.array([(1, 2, 3)], dtype='u8,u8,u8')
+        a = FA(a)
         b = np.array([(1, 2, 3)], dtype='u8,u8,u8')
+        b = FA(b)
 
         result = struct_ufunc.add_triplet(a, b)
         assert_equal(result, np.array([(2, 4, 6)], dtype='u8,u8,u8'))
@@ -1856,22 +1815,31 @@ class TestUfunc:
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_custom_ufunc(self):
         a = np.array(
-            [_rational_tests.rational(1, 2),
-             _rational_tests.rational(1, 3),
-             _rational_tests.rational(1, 4)],
-            dtype=_rational_tests.rational)
+            [
+                _rational_tests.rational(1, 2),
+                _rational_tests.rational(1, 3),
+                _rational_tests.rational(1, 4),
+            ],
+            dtype=_rational_tests.rational,
+        )
         b = np.array(
-            [_rational_tests.rational(1, 2),
-             _rational_tests.rational(1, 3),
-             _rational_tests.rational(1, 4)],
-            dtype=_rational_tests.rational)
+            [
+                _rational_tests.rational(1, 2),
+                _rational_tests.rational(1, 3),
+                _rational_tests.rational(1, 4),
+            ],
+            dtype=_rational_tests.rational,
+        )
 
         result = _rational_tests.test_add_rationals(a, b)
         expected = np.array(
-            [_rational_tests.rational(1),
-             _rational_tests.rational(2, 3),
-             _rational_tests.rational(1, 2)],
-            dtype=_rational_tests.rational)
+            [
+                _rational_tests.rational(1),
+                _rational_tests.rational(2, 3),
+                _rational_tests.rational(1, 2),
+            ],
+            dtype=_rational_tests.rational,
+        )
         assert_equal(result, expected)
 
     # FA NOT applicable
@@ -1879,14 +1847,16 @@ class TestUfunc:
     def test_custom_ufunc_forced_sig(self):
         # gh-9351 - looking for a non-first userloop would previously hang
         with assert_raises(TypeError):
-            np.multiply(_rational_tests.rational(1), 1,
-                        signature=(_rational_tests.rational, int, None))
+            np.multiply(
+                _rational_tests.rational(1),
+                1,
+                signature=(_rational_tests.rational, int, None),
+            )
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
     def test_custom_array_like(self):
-
-        class MyThing:
+        class MyThing(object):
             __array_priority__ = 1000
 
             rmul_count = 0
@@ -1905,13 +1875,13 @@ class TestUfunc:
                 if len(i) > self.ndim:
                     raise IndexError("boo")
 
-                return MyThing(self.shape[len(i):])
+                return MyThing(self.shape[len(i) :])
 
             def __rmul__(self, other):
                 MyThing.rmul_count += 1
                 return self
 
-        np.float64(5)*MyThing((3, 3))
+        np.float64(5) * MyThing((3, 3))
         assert_(MyThing.rmul_count == 1, MyThing.rmul_count)
         assert_(MyThing.getitem_count <= 2, MyThing.getitem_count)
 
@@ -1919,137 +1889,144 @@ class TestUfunc:
     def test_inplace_fancy_indexing(self):
 
         a = np.arange(10)
+        a = FA(a)
         np.add.at(a, [2, 5, 2], 1)
         assert_equal(a, [0, 1, 4, 3, 4, 6, 6, 7, 8, 9])
 
         a = np.arange(10)
+        a = FA(a)
         b = np.array([100, 100, 100])
+        b = FA(b)
         np.add.at(a, [2, 5, 2], b)
         assert_equal(a, [0, 1, 202, 3, 4, 105, 6, 7, 8, 9])
 
         a = np.arange(9).reshape(3, 3)
+        a = FA(a)
         b = np.array([[100, 100, 100], [200, 200, 200], [300, 300, 300]])
+        b = FA(b)
         np.add.at(a, (slice(None), [1, 2, 1]), b)
         assert_equal(a, [[0, 201, 102], [3, 404, 205], [6, 607, 308]])
 
         a = np.arange(27).reshape(3, 3, 3)
+        a = FA(a)
         b = np.array([100, 200, 300])
+        b = FA(b)
         np.add.at(a, (slice(None), slice(None), [1, 2, 1]), b)
-        assert_equal(a,
-            [[[0, 401, 202],
-              [3, 404, 205],
-              [6, 407, 208]],
-
-             [[9, 410, 211],
-              [12, 413, 214],
-              [15, 416, 217]],
-
-             [[18, 419, 220],
-              [21, 422, 223],
-              [24, 425, 226]]])
+        assert_equal(
+            a,
+            [
+                [[0, 401, 202], [3, 404, 205], [6, 407, 208]],
+                [[9, 410, 211], [12, 413, 214], [15, 416, 217]],
+                [[18, 419, 220], [21, 422, 223], [24, 425, 226]],
+            ],
+        )
 
         a = np.arange(9).reshape(3, 3)
+        a = FA(a)
         b = np.array([[100, 100, 100], [200, 200, 200], [300, 300, 300]])
+        b = FA(b)
         np.add.at(a, ([1, 2, 1], slice(None)), b)
         assert_equal(a, [[0, 1, 2], [403, 404, 405], [206, 207, 208]])
 
         a = np.arange(27).reshape(3, 3, 3)
+        a = FA(a)
         b = np.array([100, 200, 300])
+        b = FA(b)
         np.add.at(a, (slice(None), [1, 2, 1], slice(None)), b)
-        assert_equal(a,
-            [[[0,  1,  2],
-              [203, 404, 605],
-              [106, 207, 308]],
-
-             [[9,  10, 11],
-              [212, 413, 614],
-              [115, 216, 317]],
-
-             [[18, 19, 20],
-              [221, 422, 623],
-              [124, 225, 326]]])
+        assert_equal(
+            a,
+            [
+                [[0, 1, 2], [203, 404, 605], [106, 207, 308]],
+                [[9, 10, 11], [212, 413, 614], [115, 216, 317]],
+                [[18, 19, 20], [221, 422, 623], [124, 225, 326]],
+            ],
+        )
 
         a = np.arange(9).reshape(3, 3)
+        a = FA(a)
         b = np.array([100, 200, 300])
+        b = FA(b)
         np.add.at(a, (0, [1, 2, 1]), b)
         assert_equal(a, [[0, 401, 202], [3, 4, 5], [6, 7, 8]])
 
         a = np.arange(27).reshape(3, 3, 3)
+        a = FA(a)
         b = np.array([100, 200, 300])
+        b = FA(b)
         np.add.at(a, ([1, 2, 1], 0, slice(None)), b)
-        assert_equal(a,
-            [[[0,  1,  2],
-              [3,  4,  5],
-              [6,  7,  8]],
-
-             [[209, 410, 611],
-              [12,  13, 14],
-              [15,  16, 17]],
-
-             [[118, 219, 320],
-              [21,  22, 23],
-              [24,  25, 26]]])
+        assert_equal(
+            a,
+            [
+                [[0, 1, 2], [3, 4, 5], [6, 7, 8]],
+                [[209, 410, 611], [12, 13, 14], [15, 16, 17]],
+                [[118, 219, 320], [21, 22, 23], [24, 25, 26]],
+            ],
+        )
 
         a = np.arange(27).reshape(3, 3, 3)
+        a = FA(a)
         b = np.array([100, 200, 300])
+        b = FA(b)
         np.add.at(a, (slice(None), slice(None), slice(None)), b)
-        assert_equal(a,
-            [[[100, 201, 302],
-              [103, 204, 305],
-              [106, 207, 308]],
-
-             [[109, 210, 311],
-              [112, 213, 314],
-              [115, 216, 317]],
-
-             [[118, 219, 320],
-              [121, 222, 323],
-              [124, 225, 326]]])
+        assert_equal(
+            a,
+            [
+                [[100, 201, 302], [103, 204, 305], [106, 207, 308]],
+                [[109, 210, 311], [112, 213, 314], [115, 216, 317]],
+                [[118, 219, 320], [121, 222, 323], [124, 225, 326]],
+            ],
+        )
 
         a = np.arange(10)
+        a = FA(a)
         np.negative.at(a, [2, 5, 2])
         assert_equal(a, [0, 1, 2, 3, 4, -5, 6, 7, 8, 9])
 
         # Test 0-dim array
-        # N.B. riptable does NOT support 0-dim array
-        #a = np.array(0)
-        #np.add.at(a, (), 1)
-        #assert_equal(a, 1)
+        # N.B. FA does NOT support 0-dim array
+        # a = np.array(0)
+        # np.add.at(a, (), 1)
+        # assert_equal(a, 1)
 
-        #assert_raises(IndexError, np.add.at, a, 0, 1)
-        #assert_raises(IndexError, np.add.at, a, [], 1)
+        # assert_raises(IndexError, np.add.at, a, 0, 1)
+        # assert_raises(IndexError, np.add.at, a, [], 1)
 
         # Test mixed dtypes
         a = np.arange(10)
+        a = FA(a)
         np.power.at(a, [1, 2, 3, 2], 3.5)
         assert_equal(a, np.array([0, 1, 4414, 46, 4, 5, 6, 7, 8, 9]))
 
         # Test boolean indexing and boolean ufuncs
         a = np.arange(10)
+        a = FA(a)
         index = a % 2 == 0
         np.equal.at(a, index, [0, 2, 4, 6, 8])
         assert_equal(a, [1, 1, 1, 3, 1, 5, 1, 7, 1, 9])
 
         # Test unary operator
         a = np.arange(10, dtype='u4')
+        a = FA(a)
         np.invert.at(a, [2, 5, 2])
-        assert_equal(a, [0, 1, 2, 3, 4, 5 ^ 0xffffffff, 6, 7, 8, 9])
+        assert_equal(a, [0, 1, 2, 3, 4, 5 ^ 0xFFFFFFFF, 6, 7, 8, 9])
 
         # Test empty subspace
         orig = np.arange(4)
+        orig = FA(orig)
         a = orig[:, None][:, 0:0]
         np.add.at(a, [0, 1], 3)
         assert_array_equal(orig, np.arange(4))
 
         # Test with swapped byte order
         # N.B. riptable does not support this
-        #index = np.array([1, 2, 1], np.dtype('i').newbyteorder())
-        #values = np.array([1, 2, 3, 4], np.dtype('f').newbyteorder())
-        #np.add.at(values, index, 3)
-        #assert_array_equal(values, [1, 8, 6, 4])
+        # index = np.array([1, 2, 1], np.dtype('i').newbyteorder())
+        # values = np.array([1, 2, 3, 4], np.dtype('f').newbyteorder())
+        # np.add.at(values, index, 3)
+        # assert_array_equal(values, [1, 8, 6, 4])
 
         # Test exception thrown
         values = np.array(['a', 1], dtype=object)
+        values = FA(values)
         assert_raises(TypeError, np.add.at, values, [0, 1], 1)
         assert_array_equal(values, np.array(['a', 1], dtype=object))
 
@@ -2059,8 +2036,10 @@ class TestUfunc:
     # FA ready
     def test_reduce_arguments(self):
         f = np.add.reduce
-        d = np.ones((5,2), dtype=int)
+        d = np.ones((5, 2), dtype=int)
+        d = FA(d)
         o = np.ones((2,), dtype=d.dtype)
+        o = FA(o)
         r = o * 5
         assert_equal(f(d), r)
         # a, axis=0, dtype=None, out=None, keepdims=False
@@ -2084,8 +2063,7 @@ class TestUfunc:
         assert_equal(f(d, axis=0, dtype=None, out=None, keepdims=False), r)
         assert_equal(f(d, 0, dtype=None, out=None, keepdims=False), r)
         assert_equal(f(d, 0, None, out=None, keepdims=False), r)
-        assert_equal(f(d, 0, None, out=None, keepdims=False, initial=0,
-                       where=True), r)
+        assert_equal(f(d, 0, None, out=None, keepdims=False, initial=0, where=True), r)
 
         # too little
         assert_raises(TypeError, f)
@@ -2094,8 +2072,7 @@ class TestUfunc:
         # invalid axis
         assert_raises(TypeError, f, d, "invalid")
         assert_raises(TypeError, f, d, axis="invalid")
-        assert_raises(TypeError, f, d, axis="invalid", dtype=None,
-                      keepdims=True)
+        assert_raises(TypeError, f, d, axis="invalid", dtype=None, keepdims=True)
         # invalid dtype
         assert_raises(TypeError, f, d, 0, "invalid")
         assert_raises(TypeError, f, d, dtype="invalid")
@@ -2108,18 +2085,16 @@ class TestUfunc:
         # assert_raises(TypeError, f, d, 0, None, None, "invalid")
         # assert_raises(TypeError, f, d, keepdims="invalid", axis=0, dtype=None)
         # invalid mix
-        assert_raises(TypeError, f, d, 0, keepdims="invalid", dtype="invalid",
-                     out=None)
+        assert_raises(TypeError, f, d, 0, keepdims="invalid", dtype="invalid", out=None)
 
-        # invalid keyword
+        # invalid keyord
         assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
         assert_raises(TypeError, f, d, invalid=0)
-        assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid",
-                      out=None)
-        assert_raises(TypeError, f, d, axis=0, dtype=None, keepdims=True,
-                      out=None, invalid=0)
-        assert_raises(TypeError, f, d, axis=0, dtype=None,
-                      out=None, invalid=0)
+        assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid", out=None)
+        assert_raises(
+            TypeError, f, d, axis=0, dtype=None, keepdims=True, out=None, invalid=0
+        )
+        assert_raises(TypeError, f, d, axis=0, dtype=None, out=None, invalid=0)
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -2128,58 +2103,87 @@ class TestUfunc:
 
         class MyA(np.ndarray):
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-                return getattr(ufunc, method)(*(input.view(np.ndarray)
-                                              for input in inputs), **kwargs)
-        a = np.arange(12.).reshape(4,3)
+                return getattr(ufunc, method)(
+                    *(input.view(np.ndarray) for input in inputs), **kwargs
+                )
+
+        a = np.arange(12.0).reshape(4, 3)
         ra = a.view(dtype=('f8,f8,f8')).squeeze()
         mra = ra.view(MyA)
 
-        target = np.array([ True, False, False, False], dtype=bool)
+        target = np.array([True, False, False, False], dtype=bool)
         assert_equal(np.all(target == (mra == ra[0])), True)
 
     @pytest.mark.skip("TODO: Adapt this test for riptable?")
     def test_scalar_equal(self):
         # Scalar comparisons should always work, without deprecation warnings.
         # even when the ufunc fails.
-        a = np.array(0.)
+        a = np.array(0.0)
         b = np.array('a')
         assert_(a != b)
         assert_(b != a)
         assert_(not (a == b))
         assert_(not (b == a))
 
+    # FA ready
     def test_NotImplemented_not_returned(self):
         # See gh-5964 and gh-2091. Some of these functions are not operator
         # related and were fixed for other reasons in the past.
         binary_funcs = [
             np.power,
             # np.add, # TODO: This was removed when the numpy tests were adapted for riptable; enabling it causes the test to break -- this should be investigated/fixed.
-            np.subtract, np.multiply, np.divide,
-            np.true_divide, np.floor_divide, np.bitwise_and, np.bitwise_or,
-            np.bitwise_xor, np.left_shift, np.right_shift, np.fmax,
-            np.fmin, np.fmod, np.hypot, np.logaddexp, np.logaddexp2,
-            np.logical_and, np.logical_or, np.logical_xor, np.maximum,
-            np.minimum, np.mod,
-            np.greater, np.greater_equal, np.less, np.less_equal,
-            np.equal, np.not_equal]
+            np.subtract,
+            np.multiply,
+            np.divide,
+            np.true_divide,
+            np.floor_divide,
+            np.bitwise_and,
+            np.bitwise_or,
+            np.bitwise_xor,
+            np.left_shift,
+            np.right_shift,
+            np.fmax,
+            np.fmin,
+            np.fmod,
+            np.hypot,
+            np.logaddexp,
+            np.logaddexp2,
+            np.logical_and,
+            np.logical_or,
+            np.logical_xor,
+            np.maximum,
+            np.minimum,
+            np.mod,
+            np.greater,
+            np.greater_equal,
+            np.less,
+            np.less_equal,
+            np.equal,
+            np.not_equal,
+        ]
 
         a = np.array('1')
+        a = FA(a)
         b = 1
-        c = np.array([1., 2.])
+        c = np.array([1.0, 2.0])
+        c = FA(c)
         for f in binary_funcs:
             assert_raises(TypeError, f, a, b)
             assert_raises(TypeError, f, c, a)
 
+    # FA ready
     def test_reduce_noncontig_output(self):
         # Check that reduction deals with non-contiguous output arrays
         # appropriately.
         #
         # gh-8036
 
-        x = np.arange(7*13*8, dtype=np.int16).reshape(7, 13, 8)
-        x = x[4:6,1:11:6,1:5].transpose(1, 2, 0)
-        y_base = np.arange(4*4, dtype=np.int16).reshape(4, 4)
-        y = y_base[::2,:]
+        x = np.arange(7 * 13 * 8, dtype=np.int16).reshape(7, 13, 8)
+        x = FA(x)
+        x = x[4:6, 1:11:6, 1:5].transpose(1, 2, 0)
+        y_base = np.arange(4 * 4, dtype=np.int16).reshape(4, 4)
+        y_base = FA(y_base)
+        y = y_base[::2, :]
 
         y_base_copy = y_base.copy()
 
@@ -2188,51 +2192,8 @@ class TestUfunc:
 
         # The results should match, and y_base shouldn't get clobbered
         assert_equal(r0, r1)
-        assert_equal(y_base[1,:], y_base_copy[1,:])
-        assert_equal(y_base[3,:], y_base_copy[3,:])
-
-    @pytest.mark.parametrize('out_shape',
-                             [(), (1,), (3,), (1, 1), (1, 3), (4, 3)])
-    @pytest.mark.parametrize('keepdims', [True, False])
-    @pytest.mark.parametrize('f_reduce', [np.add.reduce, np.minimum.reduce])
-    def test_reduce_wrong_dimension_output(self, f_reduce, keepdims, out_shape):
-        # Test that we're not incorrectly broadcasting dimensions.
-        # See gh-15144 (failed for np.add.reduce previously).
-        a = np.arange(12.).reshape(4, 3)
-        out = np.empty(out_shape, a.dtype)
-
-        correct_out = f_reduce(a, axis=0, keepdims=keepdims)
-        if out_shape != correct_out.shape:
-            with assert_raises(ValueError):
-                f_reduce(a, axis=0, out=out, keepdims=keepdims)
-        else:
-            check = f_reduce(a, axis=0, out=out, keepdims=keepdims)
-            assert_(check is out)
-            assert_array_equal(check, correct_out)
-
-    def test_reduce_output_does_not_broadcast_input(self):
-        # Test that the output shape cannot broadcast an input dimension
-        # (it never can add dimensions, but it might expand an existing one)
-        a = np.ones((1, 10))
-        out_correct = (np.empty((1, 1)))
-        out_incorrect = np.empty((3, 1))
-        np.add.reduce(a, axis=-1, out=out_correct, keepdims=True)
-        np.add.reduce(a, axis=-1, out=out_correct[:, 0], keepdims=False)
-        with assert_raises(ValueError):
-            np.add.reduce(a, axis=-1, out=out_incorrect, keepdims=True)
-        with assert_raises(ValueError):
-            np.add.reduce(a, axis=-1, out=out_incorrect[:, 0], keepdims=False)
-
-    # FA ready
-    def test_reduce_output_subclass_ok(self):
-        class MyArr(np.ndarray):
-            pass
-
-        out = np.empty(())
-        np.add.reduce(np.ones(5), out=out)  # no subclass, all fine
-        out = out.view(MyArr)
-        assert np.add.reduce(np.ones(5), out=out) is out
-        assert type(np.add.reduce(out)) is MyArr
+        assert_equal(y_base[1, :], y_base_copy[1, :])
+        assert_equal(y_base[3, :], y_base_copy[3, :])
 
     # FA NOT applicable
     @pytest.mark.skip("Not applicable to riptable FastArray.")
@@ -2277,8 +2238,9 @@ class TestUfunc:
 
 
 # FA ready
-@pytest.mark.parametrize('ufunc', [getattr(np, x) for x in dir(np)
-                                if isinstance(getattr(np, x), np.ufunc)])
+@pytest.mark.parametrize(
+    'ufunc', [getattr(np, x) for x in dir(np) if isinstance(getattr(np, x), np.ufunc)]
+)
 def test_ufunc_types(ufunc):
     '''
     Check all ufuncs that the correct type is returned. Avoid
@@ -2292,7 +2254,7 @@ def test_ufunc_types(ufunc):
         if 'O' in typ or '?' in typ:
             continue
         inp, out = typ.split('->')
-        args = [np.ones((3, 3), t) for t in inp]
+        args = [rt.ones((3, 3), t) for t in inp]
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("always")
             res = ufunc(*args)
@@ -2304,12 +2266,14 @@ def test_ufunc_types(ufunc):
         else:
             assert res.dtype == np.dtype(out)
 
+
 # FA NOT support
 @pytest.mark.skip(
     "This test utilizes an operation which is explicitly not supported by FastArray."
 )
-@pytest.mark.parametrize('ufunc', [getattr(np, x) for x in dir(np)
-                                if isinstance(getattr(np, x), np.ufunc)])
+@pytest.mark.parametrize(
+    'ufunc', [getattr(np, x) for x in dir(np) if isinstance(getattr(np, x), np.ufunc)]
+)
 def test_ufunc_noncontiguous(ufunc):
     '''
     Check that contiguous and non-contiguous calls to ufuncs
@@ -2324,9 +2288,9 @@ def test_ufunc_noncontiguous(ufunc):
         args_c = [np.empty(6, t) for t in inp]
         args_n = [np.empty(18, t)[::3] for t in inp]
         for a in args_c:
-            a.flat = range(1,7)
+            a.flat = range(1, 7)
         for a in args_n:
-            a.flat = range(1,7)
+            a.flat = range(1, 7)
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("always")
             res_c = ufunc(*args_c)
@@ -2341,82 +2305,7 @@ def test_ufunc_noncontiguous(ufunc):
                 # since different algorithms (libm vs. intrinsics) can be used
                 # for different input strides
                 res_eps = np.finfo(dt).eps
-                tol = 2*res_eps
+                tol = 2 * res_eps
                 assert_allclose(res_c, res_n, atol=tol, rtol=tol)
             else:
                 assert_equal(c_ar, n_ar)
-
-
-@pytest.mark.parametrize('ufunc', [np.sign, np.equal])
-def test_ufunc_warn_with_nan(ufunc):
-    # issue gh-15127
-    # test that calling certain ufuncs with a non-standard `nan` value does not
-    # emit a warning
-    # `b` holds a 64 bit signaling nan: the most significant bit of the
-    # significand is zero.
-    b = np.array([0x7ff0000000000001], 'i8').view('f8')
-    assert np.isnan(b)
-    if ufunc.nin == 1:
-        ufunc(b)
-    elif ufunc.nin == 2:
-        ufunc(b, b.copy())
-    else:
-        raise ValueError('ufunc with more than 2 inputs')
-
-
-@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-def test_ufunc_casterrors():
-    # Tests that casting errors are correctly reported and buffers are
-    # cleared.
-    # The following array can be added to itself as an object array, but
-    # the result cannot be cast to an integer output:
-    value = 123  # relies on python cache (leak-check will still find it)
-    arr = np.array([value] * int(np.BUFSIZE * 1.5) +
-                   ["string"] +
-                   [value] * int(1.5 * np.BUFSIZE), dtype=object)
-    out = np.ones(len(arr), dtype=np.intp)
-
-    count = sys.getrefcount(value)
-    with pytest.raises(ValueError):
-        # Output casting failure:
-        np.add(arr, arr, out=out, casting="unsafe")
-
-    assert count == sys.getrefcount(value)
-    # output is unchanged after the error, this shows that the iteration
-    # was aborted (this is not necessarily defined behaviour)
-    assert out[-1] == 1
-
-    with pytest.raises(ValueError):
-        # Input casting failure:
-        np.add(arr, arr, out=out, dtype=np.intp, casting="unsafe")
-
-    assert count == sys.getrefcount(value)
-    # output is unchanged after the error, this shows that the iteration
-    # was aborted (this is not necessarily defined behaviour)
-    assert out[-1] == 1
-
-
-@pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-@pytest.mark.parametrize("offset",
-        [0, np.BUFSIZE//2, int(1.5*np.BUFSIZE)])
-def test_reduce_casterrors(offset):
-    # Test reporting of casting errors in reductions, we test various
-    # offsets to where the casting error will occur, since these may occur
-    # at different places during the reduction procedure. For example
-    # the first item may be special.
-    value = 123  # relies on python cache (leak-check will still find it)
-    arr = np.array([value] * offset +
-                   ["string"] +
-                   [value] * int(1.5 * np.BUFSIZE), dtype=object)
-    out = np.array(-1, dtype=np.intp)
-
-    count = sys.getrefcount(value)
-    with pytest.raises(ValueError):
-        # This is an unsafe cast, but we currently always allow that:
-        np.add.reduce(arr, dtype=np.intp, out=out)
-    assert count == sys.getrefcount(value)
-    # If an error occurred during casting, the operation is done at most until
-    # the error occurs (the result of which would be `value * offset`) and -1
-    # if the error happened immediately.
-    # This does not define behaviour, the output is invalid and thus undefined
-    assert out[()] < value * offset

--- a/riptable/tests/test_unique.py
+++ b/riptable/tests/test_unique.py
@@ -17,8 +17,8 @@ def test_numeric_accuracy(dt_char, lex):
     target_dtype = np.dtype(dt_char)
 
     # N.B. It's important to use .view() instead of .astype() here so the case
-    #      for np.bool is tested thoroughly; .astype(np.bool) will convert the
-    #      values to 0/1, but .view(np.bool) will not -- so it will check that
+    #      for np.bool_ is tested thoroughly; .astype(bool) will convert the
+    #      values to 0/1, but .view(bool) will not -- so it will check that
     #      lower-level logic does proper C-style bool conversion (zero=false, non-zero=true).
     nums = rand_nums.view(target_dtype)
     np_un, np_idx, np_inv, np_cnt = np.unique(
@@ -103,8 +103,8 @@ def test_bool_accuracy(dt_char, lex):
     target_dtype = np.dtype(dt_char)
 
     # N.B. It's important to use .view() instead of .astype() here so the case
-    #      for np.bool is tested thoroughly; .astype(np.bool) will convert the
-    #      values to 0/1, but .view(np.bool) will not -- so it will check that
+    #      for np.bool is tested thoroughly; .astype(bool) will convert the
+    #      values to 0/1, but .view(bool) will not -- so it will check that
     #      lower-level logic does proper C-style bool conversion (zero=false, non-zero=true).
     nums = rand_nums.view(target_dtype)
     np_un, np_idx, np_inv, np_cnt = np.unique(


### PR DESCRIPTION
This PR addresses numpy compatibility issues (#177) when using numpy 1.20 or 1.21. Many of the changes were just to fix smaller issues which caused numpy to emit ``DeprecationWarning``, but some behavioral changes in numpy 1.21 around ufuncs caused a couple of test failures that broke the riptable pip package builds.