### PR TITLE
Don't call rc.BooleanIndex() when dims mismatch

### DIFF
--- a/riptable/hypothesis_tests/test_riptide_numpy_equivalency.py
+++ b/riptable/hypothesis_tests/test_riptide_numpy_equivalency.py
@@ -30,6 +30,7 @@ from hypothesis.strategies import (
     sampled_from,
     slices,
     text,
+    just,
 )
 
 # riptable custom Hypothesis strategies
@@ -1271,6 +1272,19 @@ class TestRiptableNumpyEquivalency:
 
         inner()
 
+    @given(arrs=sampled_from([[9, 8, 7], [[10, 1],[11, 2],[13, 3]]]), inds=just([False, True, False]))
+    def test_array_bool_indexing(self, arrs, inds):
+        np_array = np.asfortranarray(arrs)
+        rt_array = rt.FA(np_array)
+
+        np_bool_indices = inds
+        rt_bool_indices = rt.FA(np_bool_indices)
+
+        nr = np_array[np_bool_indices]
+        fr = rt_array[rt_bool_indices]
+
+        assert_array_equal_(np.array(fr), nr)
+
     @given(mats=same_structure_ndarrays())
     def test_minimum(self, mats):
         mat1, mat2 = mats
@@ -1351,10 +1365,10 @@ class TestRiptableNumpyEquivalency:
                 assert isinstance(rt_output, FastArray)
 
     @pytest.mark.xfail(
-        reason=(
+        reason=
             "https://jira/browse/SOQTEST-6637 Riptable does not convert the array to a FastArray, so it does not guarantee nanstd will be an available attribute\n"
             "https://jira/browse/SOQTEST-6497 Riptable.nanstd() does not return a FastArray"
-        ),
+        ,
         raises=(AttributeError, AssertionError),
     )
     @pytest.mark.skipif(
@@ -1378,10 +1392,9 @@ class TestRiptableNumpyEquivalency:
             assert isinstance(rt_output, FastArray)
 
     @pytest.mark.xfail(
-        reason=(
-            "https://jira/browse/SOQTEST-6637 Riptable does not convert the array to a FastArray, so it does not guarantee nansum will be an available attribute\n",
+        reason=
+            "https://jira/browse/SOQTEST-6637 Riptable does not convert the array to a FastArray, so it does not guarantee nansum will be an available attribute\n"
             "nansum does not implement the axis argument either",
-        )
     )
     @pytest.mark.skipif(
         is_running_in_teamcity(), reason="Please remove alongside xfail removal."
@@ -1451,10 +1464,10 @@ class TestRiptableNumpyEquivalency:
         assert_allclose(rt_output, np_output)
 
     @pytest.mark.xfail(
-        reason=(
+        reason=
             "https://jira/browse/SOQTEST-6637 Riptable does not convert the array to a FastArray, so it does not guarantee nanvar will be an available attribute\n"
             "https://jira/browse/SOQTEST-6497 Riptable.nanvar() does not return a FastArray"
-        ),
+        ,
         raises=(AttributeError, AssertionError),
     )
     @pytest.mark.skipif(

--- a/riptable/hypothesis_tests/test_riptide_numpy_equivalency.py
+++ b/riptable/hypothesis_tests/test_riptide_numpy_equivalency.py
@@ -1273,7 +1273,7 @@ class TestRiptableNumpyEquivalency:
         inner()
 
     @given(arrs=sampled_from([[9, 8, 7], [[10, 1],[11, 2],[13, 3]]]), inds=just([False, True, False]))
-    def test_array_bool_indexing(self, arrs, inds):
+    def test_array_boolean_indexing(self, arrs, inds):
         np_array = np.asfortranarray(arrs)
         rt_array = rt.FA(np_array)
 

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -825,7 +825,7 @@ class FastArray(np.ndarray):
                 # NOTE: will fail on self.dtype.byteorder as little endian
                 if self.flags.f_contiguous:
                     # dimensions must match
-                    if self.ndim == fld.ndim:
+                    if self.ndim == fld.ndim and self.ndim == 1:
                         return TypeRegister.MathLedger._INDEX_BOOL(self,fld)
 
             # if we have fancy indexing and we support the array type, make sure we do not have stride problem

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -824,7 +824,9 @@ class FastArray(np.ndarray):
                 # make sure no striding
                 # NOTE: will fail on self.dtype.byteorder as little endian
                 if self.flags.f_contiguous:
-                    return TypeRegister.MathLedger._INDEX_BOOL(self,fld)
+                    # dimensions must match
+                    if self.ndim == fld.ndim:
+                        return TypeRegister.MathLedger._INDEX_BOOL(self,fld)
 
             # if we have fancy indexing and we support the array type, make sure we do not have stride problem
             if fld.dtype.char in NumpyCharTypes.AllInteger and self.dtype.char in NumpyCharTypes.SupportedAlternate:
@@ -1098,7 +1100,7 @@ class FastArray(np.ndarray):
         """
         low = asanyarray(low)
         high = asanyarray(high)
-        
+
         if include_low:
             ret = self >= low
         else:

--- a/riptable/tests/test_fastarray_functions.py
+++ b/riptable/tests/test_fastarray_functions.py
@@ -332,6 +332,41 @@ def test_ema_decay_requires_matching_reset_len():
     with pytest.raises(ValueError):
         data.ema_decay(times, 1.0, filter=filt, reset=larger_reset)
 
+@pytest.mark.parametrize(
+    "input,bools,expected",
+    [
+        (
+            [[10,1],[11,2],[13,3]],
+            True,
+            [[[10,1],[11,2],[13,3]]],
+        ),
+        (
+            [[10,1],[11,2],[13,3]],
+            [True, False, True],
+            [[10,1],[13,3]],
+        ),
+        (
+            [[10,1],[11,2],[13,3]],
+            [[True,False],[False,True],[True,False]],
+            [10,2,13],
+        )
+    ],
+)
+def test_boolean_indexing(input, bools, expected):
+    # we want contig bool array
+    f = np.array(bools)
+    if not f.flags.f_contiguous:
+        f = np.asfortranarray(bools)
+    assert(f.flags.f_contiguous)
+
+    na = np.asfortranarray(input)
+    assert(na.flags.f_contiguous)
+    assert_array_equal(na[f], expected)
+
+    fa = rt.FA(na)
+    assert(fa.flags.f_contiguous)
+    fr = fa[f]
+    assert_array_equal(super(rt.FA,fr), expected) # use ndarray element indexing for assertion
 
 class test_numpy_functions(unittest.TestCase):
     def assert_equal(self, lv, rv):


### PR DESCRIPTION
Fall back to numpy to do the work.
Also fix hypythesis unit tests that were failing due to failure reason type mismatch.
Fixes #190