### PR TITLE
Require at least numba 0.51

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - setuptools_scm
     - riptide_cpp >=1.6.27,<1.7
     - ansi2html >=1.5.2
-    - numba >=0.44
+    - numba >=0.51
     - python-dateutil
   run:
     - python
@@ -24,6 +24,10 @@ requirements:
     - ansi2html >=1.5.2
     - numba >=0.44
     - python-dateutil
+  run_constrained:
+      # Optional dependencies; but if installed, we require certain minimum versions.
+    - pyarrow >=3.0
+
 test:
   source_files:
     - riptable


### PR DESCRIPTION
riptable has required at least numba 0.51 for a while, but it was never enforced through the version constraint -- creating a new conda environment with numba was just getting the latest version every time. Update the conda ``meta.yaml`` to enforce that minimum version of the dependency.