### PR TITLE
Use pandas timezone conversion for to_pandas

### DIFF
--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -2548,11 +2548,10 @@ class Dataset(Struct):
                 categories = _to_unicode_if_string(col.category_array) if unicode else col.category_array
                 data[key]: pd.Categorical = pd.Categorical.from_codes(codes, categories=categories)
             elif isinstance(col, TypeRegister.DateTimeNano):
-                ccol = col.copy()
-                arr = ccol._timezone.fix_dst(ccol._fa)
-                arr = arr.astype('datetime64[ns]')
+                utc_datetime = pd.DatetimeIndex(col, tz='UTC')
                 tz = _RIPTABLE_TO_PANDAS_TZ[col._timezone._to_tz]
-                data[key] = pd.to_datetime(arr).tz_localize(tz)
+                tz_datetime = utc_datetime.tz_convert(tz)
+                data[key] = tz_datetime
             elif isinstance(col, TypeRegister.TimeSpan):
                 data[key] = pd.to_timedelta(col)
             # TODO: riptable.DateSpan doesn't have a counterpart in pandas, what do we want to do?

--- a/riptable/tests/test_dataset.py
+++ b/riptable/tests/test_dataset.py
@@ -13,7 +13,7 @@ from riptable import Struct
 from riptable import Dataset
 from riptable import Categorical
 from riptable import NumpyCharTypes
-from riptable import TimeSpan, utcnow, Date
+from riptable import DateTimeNano, TimeSpan, utcnow, Date
 from riptable.rt_numpy import arange, isnan, tile, logical
 from riptable.rt_utils import describe
 from riptable.rt_enum import (
@@ -2018,6 +2018,14 @@ class TestDataset(unittest.TestCase):
         df = pd.DataFrame({'a': [b'a', b'b']}, index=[1, 2])
         ds = Dataset.from_pandas(df)
         assert_array_equal(ds['a'], np.array([b'a', b'b']))
+
+    def test_to_pandas_dst_nonexistent(self):
+        ds = Dataset({'a': DateTimeNano(['19900401 02:00:00'], from_tz='NYC')})
+        df = ds.to_pandas()
+        fmt_string = '%Y%m%d %H:%M:%S.%f'
+        expected_arr = ds['a'].strftime(fmt_string)
+        arr = df['a'].dt.strftime(fmt_string)
+        assert_array_equal(arr, expected_arr)
 
     def test_as_pandas_df_warn(self):
         ds = Dataset({'a': [1, 2, 3]})


### PR DESCRIPTION
Current logic relies on riptable's DST and timezone conversion but pandas `tz_localize` doesn't know how to handle nonexistent timestamp because of DST (for instance 1990/4/1 2AM Eastern time doesn't exist, which is the test). The new logic will convert to pandas using the UTC timestamp and then use pandas `tz_convert` to do the timezone conversion.