### PR TITLE
Add array finalizer to date/time subclasses

### DIFF
--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -811,7 +811,7 @@ class DateBase(FastArray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        from_peer = isinstance(obj, DateTimeBase)
+        from_peer = isinstance(obj, DateBase)
         self._display_length = obj._display_length if from_peer else DisplayLength.Long
 
     # ------------------------------------------------------------

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -546,8 +546,9 @@ class DateTimeBase(FastArray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        for name in ("_display_length","_timezone",):
-            if hasattr(obj, name): setattr(self, name, getattr(obj, name))
+        from_peer = isinstance(obj, DateTimeBase)
+        self._display_length = obj._display_length if from_peer else DisplayLength.Long
+        self._timezone = obj._timezone if from_peer else 'GMT'
 
     # ------------------------------------------------------------
     @property
@@ -810,8 +811,8 @@ class DateBase(FastArray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        for name in ("_display_length",):
-            if hasattr(obj, name): setattr(self, name, getattr(obj, name))
+        from_peer = isinstance(obj, DateTimeBase)
+        self._display_length = obj._display_length if from_peer else DisplayLength.Long
 
     # ------------------------------------------------------------
     def strftime(self, format, dtype='O'):

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -547,6 +547,7 @@ class DateTimeBase(FastArray):
         if obj is None:
             return
         self._timezone = getattr(obj, "_timezone", None)
+        self._display_length = getattr(obj, "_display_length", None)
 
     # ------------------------------------------------------------
     @property

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -546,8 +546,8 @@ class DateTimeBase(FastArray):
     def __array_finalize__(self, obj):
         if obj is None:
             return
-        self._timezone = getattr(obj, "_timezone", None)
-        self._display_length = getattr(obj, "_display_length", None)
+        for name in ("_display_length","_timezone",):
+            if hasattr(obj, name): setattr(self, name, getattr(obj, name))
 
     # ------------------------------------------------------------
     @property
@@ -805,6 +805,13 @@ class DateBase(FastArray):
     # ------------------------------------------------------------
     def __repr__(self):
         return self.get_classname() + "([" + self._build_string() + "])"
+
+    # ------------------------------------------------------------
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        for name in ("_display_length",):
+            if hasattr(obj, name): setattr(self, name, getattr(obj, name))
 
     # ------------------------------------------------------------
     def strftime(self, format, dtype='O'):
@@ -5382,6 +5389,7 @@ class DateScalar(np.int32):
     '''
 
     __slots__ = '_display_length'
+
     # ------------------------------------------------------------
     def __new__(cls, arr, **kwargs):
         return super().__new__(cls, arr)
@@ -5394,6 +5402,10 @@ class DateScalar(np.int32):
             self._display_length = _from._display_length
         else:
             self._display_length = DisplayLength.Long
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
 
     def get_item_format(self):
         item_format = ItemFormat(

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -543,6 +543,12 @@ class DateTimeBase(FastArray):
         return instance
 
     # ------------------------------------------------------------
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self._timezone = getattr(obj, "_timezone", None)
+
+    # ------------------------------------------------------------
     @property
     def _fa(self):
         return self.view(FastArray)
@@ -1658,7 +1664,7 @@ class Date(DateBase, TimeStampBase):
     #def __floordiv__(self, other): raise NotImplementedError
     #def __mod__(self, other): raise NotImplementedError
     #def __divmod__(self, other): raise NotImplementedError
-    
+
     def __pow__(self, other, modulo=None): raise NotImplementedError
 
     def __lshift__(self, other): raise NotImplementedError
@@ -4322,7 +4328,7 @@ class DateTimeNano(DateTimeBase, TimeStampBase, DateTimeCommon):
     #def __floordiv__(self, other): raise NotImplementedError
     #def __mod__(self, other): raise NotImplementedError
     #def __divmod__(self, other): raise NotImplementedError
-    
+
     def __pow__(self, other, modulo=None): raise NotImplementedError
 
     def __lshift__(self, other): raise NotImplementedError
@@ -4869,7 +4875,7 @@ class TimeSpanBase:
             timestr = DateTimeBase.DEFAULT_FORMATTER(format_str, gmt_time)
 
             days = np.int64(item) // NANOS_PER_DAY
-            
+
             if days > 0:
                 timestr = str(days) + 'd ' + timestr
             if nanosecs < 0:

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -544,6 +544,8 @@ class DateTimeBase(FastArray):
 
     # ------------------------------------------------------------
     def __array_finalize__(self, obj):
+        '''Finalizes self from other, called as part of ndarray.__new__()'''
+        super().__array_finalize__(obj)
         if obj is None:
             return
         from_peer = isinstance(obj, DateTimeBase)
@@ -809,6 +811,8 @@ class DateBase(FastArray):
 
     # ------------------------------------------------------------
     def __array_finalize__(self, obj):
+        '''Finalizes self from other, called as part of ndarray.__new__()'''
+        super().__array_finalize__(obj)
         if obj is None:
             return
         from_peer = isinstance(obj, DateBase)

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -548,7 +548,7 @@ class DateTimeBase(FastArray):
             return
         from_peer = isinstance(obj, DateTimeBase)
         self._display_length = obj._display_length if from_peer else DisplayLength.Long
-        self._timezone = obj._timezone if from_peer else 'GMT'
+        self._timezone = obj._timezone if from_peer else TypeRegister.TimeZone(from_tz='UTC', to_tz='UTC')
 
     # ------------------------------------------------------------
     @property

--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -5403,10 +5403,6 @@ class DateScalar(np.int32):
         else:
             self._display_length = DisplayLength.Long
 
-    def __array_finalize__(self, obj):
-        if obj is None:
-            return
-
     def get_item_format(self):
         item_format = ItemFormat(
             length=self._display_length,

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -495,6 +495,12 @@ class FastArray(np.ndarray):
 
         return instance.view(cls)
 
+    def __array_finalize__(self, obj):
+        '''Finalizes self from other, called as part of ndarray.__new__()'''
+        if obj is None:
+            return
+        from_peer = isinstance(obj, FastArray)
+        if from_peer and hasattr(obj, '_name'): self._name = obj._name
 
     #--------------------------------------------------------------------------
     def __reduce__(self):

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2605,9 +2605,26 @@ def test_concatenate_preserves_datetime_type_regression(typ, arrays):
         #pytest.param(TimeSpanScalar(8.76543), id='TimeSpanScalar'),
     ]
 )
-def test_view_casting(obj):
-    members = dir(obj)
+def test_new_from_template(obj):
     objView = obj.view()
+    members = dir(obj)
+    viewMembers = dir(objView)
+    missing = [m for m in members if m not in viewMembers]
+    assert len(missing) == 0, f"Not found: {missing}"
+
+@pytest.mark.parametrize(
+    "cls,arr",
+    [
+        pytest.param(Date, np.array(['2018-02-01']), id='Date'),
+        pytest.param(DateSpan, np.array([123]), id='DateSpan'),
+        pytest.param(DateTimeNano, np.array([1632164888]), id='DateTimeNano'),
+        pytest.param(TimeSpan, np.array(['12.34']), id='TimeSpan'),
+    ]
+)
+def test_view_casting(cls, arr):
+    obj = cls(arr)
+    objView = obj.view()
+    members = dir(obj)
     viewMembers = dir(objView)
     missing = [m for m in members if m not in viewMembers]
     assert len(missing) == 0, f"Not found: {missing}"

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2596,7 +2596,8 @@ def test_concatenate_preserves_datetime_type_regression(typ, arrays):
     [
         pytest.param(Date(['2018-02-01']), id='Date'),
         pytest.param(DateSpan([123]), id='DateSpan'),
-        pytest.param(DateTimeNano(['19900401 02:00:00'], from_tz='NYC'), id='DateTimeNano'),
+        pytest.param(DateTimeNano(['19900401 02:00:00'], from_tz='NYC'), id='DateTimeNano_NYC'),
+        pytest.param(DateTimeNano(['20210921 02:21:21'], from_tz='GMT'), id='DateTimeNano_GMT'),
         pytest.param(TimeSpan(['12.34']), id='TimeSpan'),
         # the following don't return the same type from self.view()
         #pytest.param(DateScalar(34567), id='DateScalar'),
@@ -2607,6 +2608,7 @@ def test_concatenate_preserves_datetime_type_regression(typ, arrays):
 )
 def test_new_from_template(obj):
     objView = obj.view()
+    assert repr(objView) == repr(obj)
     members = dir(obj)
     viewMembers = dir(objView)
     missing = [m for m in members if m not in viewMembers]
@@ -2624,6 +2626,7 @@ def test_new_from_template(obj):
 def test_view_casting(cls, arr):
     obj = cls(arr)
     objView = obj.view()
+    assert repr(objView) == repr(obj)
     members = dir(obj)
     viewMembers = dir(objView)
     missing = [m for m in members if m not in viewMembers]

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2511,6 +2511,68 @@ class DateTime_Test(unittest.TestCase):
         self.assertTrue( (TimeSpan(['12:00:00']) == '12:00:00').all() )
         self.assertTrue((TimeSpan(['12:00:00'])[0] == '12:00:00').all())
 
+    def test_datetimenano_view_unspecified_type(self) -> None:
+        """Test how DateTimeNano.view() behaves when an output type is not explicitly specified."""
+        arr = DateTimeNano(
+            [
+                '20191119 09:30:17.557593707',
+                '20191119 15:31:32.216792000',
+                '20191121 11:28:23.519020994',
+                '20191121 11:28:56.822878000',
+                '20191121 14:01:39.112893000',
+                '20191121 15:46:10.838007105',
+                '20191122 11:53:05.974525000',
+                '20191125 10:40:32.079135847',
+                '20191126 10:00:43.232329062',
+                '20191126 14:04:31.421071000',
+            ],
+            from_tz='NYC',
+            to_tz='NYC',
+        )
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr.view()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # DateTimeNano-specific checks
+        self.assertEqual(arr._timezone, arr_view._timezone)
+
+    def test_date_view_unspecified_type(self) -> None:
+        """Test how Date.view() behaves when an output type is not explicitly specified."""
+        arr = Date(['2019-11-04', '2019-11-04', '2019-11-04', '2019-11-11'])
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr.view()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # Date-specific checks
+        # (None)
+
+    def test_timespan_view_unspecified_type(self) -> None:
+        """Test how Date.view() behaves when an output type is not explicitly specified."""
+        arr = TimeSpan([
+            '09:30:17.557593707',
+            '15:31:32.216792000',
+            '11:28:23.519020994',
+            '19:46:10.838007105',
+            '09:30:29.999999999',
+            '10:40:00.000000000',
+            '00:00:00.999999999',
+            '23:59:59.999999999',
+        ])
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr.view()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+        # TimeSpan-specific checks
+        # (None)
 
 class TestTimeZone(unittest.TestCase):
     def test_equal_positive(self) -> None:

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -1199,8 +1199,8 @@ class DateTime_Test(unittest.TestCase):
 
     def test_dst_fall_hour(self):
         '''
-        When daylight savings time ends, clocks go back one hour. However, UTC is 
-        does not change. Initializing times in different hours in UTC on the changing hour 
+        When daylight savings time ends, clocks go back one hour. However, UTC is
+        does not change. Initializing times in different hours in UTC on the changing hour
         will yield the same result in a specific timezone.
         '''
 
@@ -1451,8 +1451,8 @@ class DateTime_Test(unittest.TestCase):
         ])
         expected = FastArray([93017, 153132, 112823, 194610, 93029, 104000, 0, 235959])
         actual = timespan.hhmmss
-        self.assertTrue(np.all(expected == actual)) 
-        
+        self.assertTrue(np.all(expected == actual))
+
     def test_round_nano_time(self):
         correct_str = "'20181231 23:59:59.999999999'"
         correct_iso = b'2018-12-31T23:59:59.999999999'
@@ -2591,6 +2591,11 @@ def test_concatenate_preserves_datetime_type_regression(typ, arrays):
     result = concatenate(arrays)
     assert isinstance(result, typ)
 
+def test_view_ctor():
+    dtn = DateTimeNano(['19900401 02:00:00'], from_tz='NYC')
+    assert(dtn._timezone is not None)
+    v = dtn.view('i8')
+    assert(v._timezone is not None)
 
 if __name__ == '__main__':
     tester = unittest.main()

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2591,11 +2591,26 @@ def test_concatenate_preserves_datetime_type_regression(typ, arrays):
     result = concatenate(arrays)
     assert isinstance(result, typ)
 
-def test_view_ctor():
-    dtn = DateTimeNano(['19900401 02:00:00'], from_tz='NYC')
-    assert(dtn._timezone is not None)
-    v = dtn.view('i8')
-    assert(v._timezone is not None)
+@pytest.mark.parametrize(
+    "obj",
+    [
+        pytest.param(Date(['2018-02-01']), id='Date'),
+        pytest.param(DateSpan([123]), id='DateSpan'),
+        pytest.param(DateTimeNano(['19900401 02:00:00'], from_tz='NYC'), id='DateTimeNano'),
+        pytest.param(TimeSpan(['12.34']), id='TimeSpan'),
+        # the following don't return the same type from self.view()
+        #pytest.param(DateScalar(34567), id='DateScalar'),
+        #pytest.param(DateSpanScalar(12345), id='DateSpanScalar'),
+        #pytest.param(DateTimeNanoScalar(87654321), id='DateTimeNanoScalar'),
+        #pytest.param(TimeSpanScalar(8.76543), id='TimeSpanScalar'),
+    ]
+)
+def test_view_casting(obj):
+    members = dir(obj)
+    objView = obj.view()
+    viewMembers = dir(objView)
+    missing = [m for m in members if m not in viewMembers]
+    assert len(missing) == 0, f"Not found: {missing}"
 
 if __name__ == '__main__':
     tester = unittest.main()

--- a/riptable/tests/test_fastarray.py
+++ b/riptable/tests/test_fastarray.py
@@ -1489,7 +1489,18 @@ class FastArray_Test(unittest.TestCase):
         assert 0 == np.sum(rt.FA([], dtype=np.int32), dtype=np.int64)
         assert 0 == np.nansum(rt.FA([], dtype=np.uint8), dtype=np.int32)
         assert 0 == np.nansum(rt.FA([], dtype=np.float64), dtype=np.float64)
-        
+
+    def test_view_unspecified_type(self) -> None:
+        """Test how FastArray.view() behaves when an output type is not explicitly specified."""
+        arr = FastArray([6, 8, 10, 10, 0, 5, 2], dtype=np.uint32)
+        arr.set_name(f"my_test_{type(arr).__name__}")
+        arr_view = arr.view()
+        self.assertEqual(type(arr), type(arr_view))
+        self.assertEqual(arr.shape, arr_view.shape)
+        self.assertFalse(arr_view.flags.owndata)
+        self.assertEqual(arr.get_name(), arr_view.get_name())
+        self.assertTrue((arr == arr_view).all())
+
 # TODO: Extend the tests in the TestFastArrayNanmax / TestFastArrayNanmin classes below to cover the following cases:
 #   * non-array inputs (e.g. a list or set or scalar)
 #   * other FastArray subclass, e.g. Date


### PR DESCRIPTION
Per https://numpy.org/doc/stable/user/basics.subclassing.html, in order to handle post-view casting initialization.
Fixes #206