### PR TITLE
Retain arr dtype for quantile(arr)

### DIFF
--- a/riptable/rt_bin.py
+++ b/riptable/rt_bin.py
@@ -126,11 +126,8 @@ def quantile(x, q, interpolation_method: str='fraction'):
         q = np.asarray(q, np.float64)
         # print("***",q)
         length = q.shape[0]
-        i = 0
+        result = np.array([_get_score(q[i]) for i in range(length)])
 
-        result = np.empty(length, dtype=np.object_)
-        for i in range(length):
-            result[i] = _get_score(q[i])
         return result, lsort, counts
 
 

--- a/riptable/tests/test_cut.py
+++ b/riptable/tests/test_cut.py
@@ -160,6 +160,11 @@ class Cut_Test(unittest.TestCase):
                 labels=['a', 'b', 'c', 'd', 'e', 'f'],
             )
 
+    def test_qcut_drop_dups(self):
+        c = qcut([1,1,1,1,1,1,1,2,2,2,11,12,13], 4, duplicates = 'drop')
+        self.assertIsInstance(c, Categorical)
+        self.assertTrue(sum(c._np - FA([2,2,2,2,2,2,2,2,2,2,3,3,3])) == 0)
+        self.assertTrue((c.category_array == [b'Clipped', b'1.0->2.0', b'2.0->13.0']).all())
 
 if __name__ == "__main__":
     tester = unittest.main()


### PR DESCRIPTION
Avoids changing sorting behavior between numeric and
object types, which affects qcut() behavior.
Fixes #229