### PR TITLE
Fix tests for pyarrow 6.0 break

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - nose >=1.3.7  # nose because ipykernel testing utilities still have nose imports
     # Include pyarrow as a test requirement. It's an optional dependency at run-time,
     # but we want to be able to run interop tests with it.
-    - pyarrow >=4.0.0
+    - pyarrow >=6.0.0
 
     # Known issues where ipykernel dies before reply messages.
     # The following ipykernel and jupyter_console versions are verified to work.

--- a/riptable/tests/test_interop_pyarrow.py
+++ b/riptable/tests/test_interop_pyarrow.py
@@ -178,7 +178,7 @@ class TestPyarrowConvertCategorical:
         if have_nulls:
             # pyarrow uses an INvalid mask (where True means null/NA).
             invalid_mask = indices % 7 == 3
-            pa_indices = pa.array(indices, mask=pa.array(invalid_mask))
+            pa_indices = pa.array(indices, mask=invalid_mask)
             pa_arr = pa.DictionaryArray.from_arrays(pa_indices, cat_labels, ordered=ordered)
         else:
             pa_arr = pa.DictionaryArray.from_arrays(indices, cat_labels, ordered=ordered)


### PR DESCRIPTION
The pyarrow interop test was constructing a masked array as a mix of nd.array and pyarrow.array, which is no longer valid in pyarrow v6.0. Passing both as nd.array fixes the test.