### PR TITLE
Make all usages of numba respect the global setting controlling caching

### DIFF
--- a/riptable/rt_fastarraynumba.py
+++ b/riptable/rt_fastarraynumba.py
@@ -1,21 +1,25 @@
-__all__ = ['fill_forward', 'fill_backward']
+__all__ = [
+    'fill_forward', 'fill_backward'
+]
 
 #---------------------------------------------------------------------
 # This file is for numba routines that work on numpy arrays
 # It is different from CPP routines in the riptide_cpp module
 # Others are encouraged to add
 #
+from typing import Optional, Union
+import warnings
+
 import numpy as np
 import numba as nb
-import warnings
-from typing import Optional, Union
 
+from .config import get_global_settings
 from .rt_enum import INVALID_DICT
 from .rt_fastarray import FastArray
 from .rt_numpy import empty_like
 
 #-----------------------------------------------------
-@nb.jit(cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def fill_forward_float(arr, fill_val, limit):
     lastgood = fill_val
     if limit <= 0:
@@ -38,7 +42,7 @@ def fill_forward_float(arr, fill_val, limit):
                 lastgood = arr[idx]
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def fill_forward_int(arr, inv, fill_val, limit):
     lastgood = fill_val
     if limit <= 0:
@@ -62,7 +66,7 @@ def fill_forward_int(arr, inv, fill_val, limit):
 
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def fill_backward_float(arr, fill_val, limit):
     lastgood = fill_val
     if limit <= 0:
@@ -85,7 +89,7 @@ def fill_backward_float(arr, fill_val, limit):
                 lastgood = arr[idx]
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def fill_backward_int(arr, inv, fill_val, limit):
     lastgood = fill_val
     if limit <= 0:
@@ -250,7 +254,7 @@ def fill_backward(arr: np.ndarray, fill_val=None, inplace:bool=False, limit:int=
     return arr
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_cummin_int(arr: np.ndarray, ret: np.ndarray, inv, skipna):
     if skipna:
         for j in range(len(arr)):
@@ -273,7 +277,7 @@ def nb_cummin_int(arr: np.ndarray, ret: np.ndarray, inv, skipna):
             ret[i]=running_min
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_cummin_float(arr: np.ndarray, ret: np.ndarray, skipna):
     if skipna:
         for j in range(len(arr)):
@@ -297,7 +301,7 @@ def nb_cummin_float(arr: np.ndarray, ret: np.ndarray, skipna):
 
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_cummax_int(arr: np.ndarray, ret: np.ndarray, inv, skipna):
     if skipna:
         for j in range(len(arr)):
@@ -320,7 +324,7 @@ def nb_cummax_int(arr: np.ndarray, ret: np.ndarray, inv, skipna):
             ret[i]=running_max
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_cummax_float(arr: np.ndarray, ret: np.ndarray, skipna):
     if skipna:
         for j in range(len(arr)):
@@ -421,7 +425,7 @@ def cummin(arr: np.ndarray, skipna=True):
 
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_ema_decay_with_filter_and_reset(arr, dest, time, decayRate,  filter, resetmask):
     lastEma = 0
     lastTime = 0
@@ -441,7 +445,7 @@ def nb_ema_decay_with_filter_and_reset(arr, dest, time, decayRate,  filter, rese
         dest[i] = lastEma
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_ema_decay_with_filter(arr, dest, time, decayRate, filter):
     lastEma = 0
     lastTime = 0
@@ -457,7 +461,7 @@ def nb_ema_decay_with_filter(arr, dest, time, decayRate, filter):
         dest[i] = lastEma
 
 #-----------------------------------------------------
-@nb.jit(nopython=True, cache=True)
+@nb.njit(parallel=False, cache=get_global_settings().enable_numba_cache, nogil=True)
 def nb_ema_decay(arr, dest, time, decayRate):
     lastEma = 0.0
     lastTime = 0

--- a/riptable/rt_grouping.py
+++ b/riptable/rt_grouping.py
@@ -20,6 +20,7 @@ import numpy as np
 import numba as nb
 import riptide_cpp as rc
 
+from .config import get_global_settings
 from .rt_numpy import (
     arange,
     combine_accum1_filter, combine_accum2_filter, combine_filter, combine2keys,
@@ -2640,7 +2641,7 @@ class Grouping:
                         pass
                         # TJD future speed ups will use a numba loop such as below
                         #import numba as nb
-                        #@nb.jit(parallel=True, nopython=True)
+                        #@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
                         #def _numba_nonreduce2_1(userfunc, ifirst, ncount, in1, in2, kwarg1):
                         #    for i in nb.prange(1, ifirst.shape[0]):
                         #        first=ifirst[i]
@@ -2648,7 +2649,7 @@ class Grouping:
                         #        # call the user func with one or more input arrays, one or more output arrays, any additional args, kwargs
                         #        userfunc(in1[first:last], in2[first:last], kwarg1)
 
-                        #@nb.jit(parallel=True, nopython=True)
+                        #@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
                         #def _numba_nonreduce2_2(userfunc, ifirst, ncount, in1, in2, kwarg1, kwarg2):
                         #    for i in nb.prange(1, ifirst.shape[0]):
                         #        first=ifirst[i]
@@ -2656,7 +2657,7 @@ class Grouping:
                         #        # call the user func with one or more input arrays, one or more output arrays, any additional args, kwargs
                         #        userfunc(in1[first:last], in2[first:last], kwarg1, kwarg2)
 
-                        #@nb.jit(parallel=True, nopython=True)
+                        #@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
                         #def _numba_nonreduce3_1(userfunc, ifirst, ncount, in1, in2, in3, kwarg1):
                         #    for i in nb.prange(1, ifirst.shape[0]):
                         #        first=ifirst[i]
@@ -2664,7 +2665,7 @@ class Grouping:
                         #        # call the user func with one or more input arrays, one or more output arrays, any additional args, kwargs
                         #        userfunc(in1[first:last], in2[first:last], in3[first:last], kwarg1)
 
-                        #@nb.jit(parallel=True, nopython=True)
+                        #@nb.njit(parallel=True, cache=get_global_settings().enable_numba_cache, nogil=True)
                         #def _numba_nonreduce3_2(userfunc, ifirst, ncount, in1, in2, in3, kwarg1, kwarg2):
                         #    for i in nb.prange(1, ifirst.shape[0]):
                         #        first=ifirst[i]

--- a/riptable/rt_str.py
+++ b/riptable/rt_str.py
@@ -193,7 +193,7 @@ class FAString(FastArray):
 
         default signature must match
 
-        @nb.jit(nopython=True, cache=True)
+        @nb.njit(cache=get_global_settings().enable_numba_cache, nogil=True)
         def nb_upper(src, itemsize, dest):
 
         src: is uint array
@@ -208,9 +208,9 @@ class FAString(FastArray):
         Example:
         -------
         import numba as nb
-        @nb.jit(nopython=True, cache=True)
+        @nb.njit(cache=get_global_settings().enable_numba_cache, nogil=True)
         def nb_upper(src, itemsize, dest):
-            for i in range(len(src) / itemsize):
+            for i in nb.prange(len(src) / itemsize):
                 rowpos = i * itemsize
                 for j in range(itemsize):
                     c=src[rowpos+j]
@@ -463,7 +463,7 @@ class FAString(FastArray):
         --------
         >>> FAString(['this','that','test']).upper
         FastArray(['THIS','THAT','TEST'], dtype='<U4')
-        
+
         '''
         return self._apply_func(self.nb_upper, self.nb_upper_par)
 
@@ -564,7 +564,7 @@ class FAString(FastArray):
         Parameters
         ----------
         str2 - a string with one or more characters to search for
-        
+
         Examples
         --------
         >>> FAString(['this  ','that ','test']).index_any_of('ia')
@@ -594,7 +594,7 @@ class FAString(FastArray):
         Parameters
         ----------
         str2 - a string with one or more characters to search for
-        
+
         Examples
         --------
         >>> FAString(['this  ','that ','test']).index('at')
@@ -625,7 +625,7 @@ class FAString(FastArray):
         Parameters
         ----------
         str2 - a string with one or more characters to search for
-        
+
         Examples
         --------
         >>> FAString(['this  ','that ','test']).contains('at')
@@ -655,7 +655,7 @@ class FAString(FastArray):
         Parameters
         ----------
         str2 - a string with one or more characters to search for
-        
+
         Examples
         --------
         >>> FAString(['this  ','that ','test']).startswith('thi')
@@ -681,7 +681,7 @@ class FAString(FastArray):
         Parameters
         ----------
         str2 - a string with one or more characters to search for
-        
+
         Examples
         --------
         >>> FAString(['abab','ababa','abababb']).endswith('ab')


### PR DESCRIPTION
#144 missed some usages of numba and caching was enabled for most of these, leading to the same crashing behavior. This PR fixes the rest of the numba-decorated functions in the library so they respect the global setting controlling whether numba caching is enabled for functions (or not).