### PR TITLE
Fix Dataset.melt() for hstackable types

### DIFF
--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -5256,7 +5256,7 @@ class Dataset(Struct):
             mdata[col] = np.tile(id_data._np,K)
 
         mdata[var_name] = FastArray(list(tempdict.keys())).repeat(N)
-        mdata[value_name] = hstack(tempdict.values())
+        mdata[value_name] = hstack(list(tempdict.values()))
         if trim:
             goodmask = ~mdata[value_name].isnanorzero()
             mdata=mdata[goodmask,:]

--- a/riptable/tests/test_dataset.py
+++ b/riptable/tests/test_dataset.py
@@ -1032,6 +1032,18 @@ class TestDataset(unittest.TestCase):
         )
         self.assertTrue((tm2 == tm2t).all(axis=None))
 
+    def test_melt_datetimenano(self):
+        ds = Dataset({'A': ['a', 'b', 'c'],
+            't':rt.DateTimeNano(['20200925 10:00','20200926 10:00','20200927 10:00'], from_tz='NYC')})
+        ds['t1'] = ds['t'] + 1e9 * 60
+        ds['t2'] = ds['t'] + 1e9 * 60 * 2
+        tm0 = Dataset({'A': ['a', 'b', 'c', 'a', 'b', 'c', 'a','b', 'c'],
+            'variable': ['t', 't', 't', 't1', 't1', 't1', 't2', 't2', 't2'],
+            'value': rt.DateTimeNano(['20200925 10:00','20200926 10:00','20200927 10:00','20200925 10:01','20200926 10:01','20200927 10:01','20200925 10:02','20200926 10:02','20200927 10:02'], from_tz='NYC')})
+        tm0t = ds.melt(id_vars=['A'])
+        result = (tm0 == tm0t)
+        self.assertTrue(result.all(axis=None))
+
     def test_pivot(self):
         pass
 


### PR DESCRIPTION
Pass a list of dict values to underlying hstack() as required.
Fixes #260