### PR TITLE
Expand dtype to int64 before converting to seconds

### DIFF
--- a/riptable/rt_datetime.py
+++ b/riptable/rt_datetime.py
@@ -818,7 +818,7 @@ class DateBase(FastArray):
     # ------------------------------------------------------------
     def strftime(self, format, dtype='O'):
         '''
-        Converts DateTimeNano to an array of object strings or a scalar string.
+        Converts Date, etc. to an array of object strings or a scalar string.
         This routine has not been sped up yet.
 
         Other Parameters
@@ -837,7 +837,7 @@ class DateBase(FastArray):
 
         '''
         if isinstance(self, np.ndarray):
-            return np.asarray([dt.utcfromtimestamp(timestamp).strftime(format) for timestamp in self._fa* SECONDS_PER_DAY], dtype=dtype)
+            return np.asarray([dt.utcfromtimestamp(timestamp).strftime(format) for timestamp in self._fa.astype(np.int64) * SECONDS_PER_DAY], dtype=dtype)
         else:
             return dt.strftime(dt.utcfromtimestamp(self * SECONDS_PER_DAY), format)
 
@@ -4908,7 +4908,7 @@ class TimeSpanBase:
     # ------------------------------------------------------------
     def strftime(self, format, dtype='U'):
         '''
-        Converts DateTimeNano to an array of object strings or a scalar string.
+        Converts TimeSpan to an array of object strings or a scalar string.
         This routine has not been sped up yet.
 
         Other Parameters
@@ -5777,7 +5777,7 @@ class DateScalar(np.int32):
         http://strftime.org  for format strings
         datetime.datetime.strftime
         '''
-        return dt.strftime(dt.utcfromtimestamp(self * SECONDS_PER_DAY), format)
+        return dt.strftime(dt.utcfromtimestamp(self.astype(np.int64) * SECONDS_PER_DAY), format)
 
     # ------------------------------------------------------------
     @property

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2501,6 +2501,20 @@ class DateTime_Test(unittest.TestCase):
         ret = Date(utcnow(4))[0].strftime('%D')
         # make sure a string was returned
         self.assertTrue(isinstance(ret, str))
+        ret = Date('2038-01-19')[0].strftime('%Y%m%d')
+        self.assertEquals('20380119', ret)
+        ret = Date('2038-01-20')[0].strftime('%Y%m%d')
+        self.assertEquals('20380120', ret)
+        ret = Date('2099-12-31')[0].strftime('%Y%m%d')
+        self.assertEquals('20991231', ret)
+
+    def test_datescalars_strftime(self):
+        ret = Date('2038-01-19').strftime('%Y%m%d')
+        self.assertTrue(('20380119' == ret).all())
+        ret = Date('2038-01-20').strftime('%Y%m%d')
+        self.assertTrue(('20380120' == ret).all())
+        ret = Date('2099-12-31').strftime('%Y%m%d')
+        self.assertTrue(('20991231' == ret).all())
 
     def test_timespandivision(self):
         x = TimeSpan('00:30:00')[0] / TimeSpan('01:00:00')[0]


### PR DESCRIPTION
Avoids numeric overflow of DateScalar int32
Fixes #277