### PR TITLE
Add numpy version to meta.yaml

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - setuptools_scm
     - riptide_cpp >=1.7.5,<1.8
     - ansi2html >=1.5.2
+    - numpy >=1.20,<1.21
     - numba >=0.51
     - python-dateutil
   run:
@@ -22,6 +23,7 @@ requirements:
     - {{ pin_compatible('riptide_cpp', min_pin='x.x.x', max_pin='x.x') }}
     - pandas >=0.24,<2.0
     - ansi2html >=1.5.2
+    - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
     - numba >=0.51
     - python-dateutil
 


### PR DESCRIPTION
Make the numpy dependency explicit rather than expecting it to be set up properly.
Ensures that we use the correct numpy version that's required by numba.