### PR TITLE
Use unique cat column name in apply() result

### DIFF
--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -3927,9 +3927,7 @@ class Categorical(GroupByOps, FastArray):
         result = super(Categorical, clean_c).apply(userfunc, *args, dataset=dataset, label_keys=clean_c.gb_keychain, **kwargs)
         # result is the same size as original, attach categorical (the key column) to result
         if result.shape[0] == len(clean_c):
-            name = self.get_header_names([self], default='gb_key_')[0]
-            result[name] = self
-            result.label_set_names(name)
+            self._attach_self_as_key_column(result)
         return result
 
     # ------------------------------------------------------------
@@ -3942,10 +3940,19 @@ class Categorical(GroupByOps, FastArray):
         result = super(Categorical, clean_c).apply_nonreduce(userfunc, *args, dataset=dataset, label_keys=clean_c.gb_keychain, **kwargs)
         # result is the same size as original, attach categorical (the key column) to result
         if result.shape[0] == len(clean_c):
-            name = self.get_header_names([self], default='gb_key_')[0]
-            result[name] = self
-            result.label_set_names(name)
+            self._attach_self_as_key_column(result)
         return result
+
+    def _attach_self_as_key_column(self, result):
+        name_pattern = 'gb_key_'
+        names = self.get_header_names([self])
+        name = None
+        for i in range(sys.maxsize): # find a unique name
+            name = name_pattern + str(i)
+            if not name in names:
+                break
+        result[name] = self
+        result.label_set_names(name)
 
     # ------------------------------------------------------------
     @property

--- a/riptable/rt_categorical.py
+++ b/riptable/rt_categorical.py
@@ -11,6 +11,7 @@ __all__ = [
 from enum import IntEnum, EnumMeta
 from typing import Any, Collection, Dict, List, Mapping, Optional, Tuple, Union, TYPE_CHECKING
 import warnings
+import sys
 
 import numpy as np
 


### PR DESCRIPTION
If we need to add the categorical itself to the results of an apply() operation, add it with a unique name.
The previous implementation appears to have depended on the first entry in the names array to be None, so it would be defaulted to the unique name. Now that we use array_finalizer, arrays created from template may get the template array's name, and in this case would cause the result column being overwritten.

Fixes #285 