### PR TITLE
Remove numpy from build hash

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - setuptools_scm
     - riptide_cpp >=1.7.5,<1.8
     - ansi2html >=1.5.2
-    - numpy >=1.20,<1.21
+    #- numpy >=1.20,<1.21
     - numba >=0.51
     - python-dateutil
   run:
@@ -23,7 +23,8 @@ requirements:
     - {{ pin_compatible('riptide_cpp', min_pin='x.x.x', max_pin='x.x') }}
     - pandas >=0.24,<2.0
     - ansi2html >=1.5.2
-    - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
+    #- {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
+    - numpy >=1.20,<1.21
     - numba >=0.51
     - python-dateutil
 


### PR DESCRIPTION
Remove numpy from build section.
Retain it in run section, as that doesn't affect build hash.