### PR TITLE
Retain filtered index in Grouping.regroup()

### DIFF
--- a/riptable/rt_grouping.py
+++ b/riptable/rt_grouping.py
@@ -2066,7 +2066,8 @@ class Grouping:
 
             # uniques didn't change, fix the new ikey to match old ordering
             if self._unique_count == unique_count_new:
-                if filter is None:
+                # fast path if not filtering and not already filtered
+                if filter is None and ikey_new.min() > 0:
                     ikey_fix = self.ikey[ifirstkey][ikey_new-1]
                 else:
                     # TJD this path needs to be tested

--- a/riptable/tests/test_grouping.py
+++ b/riptable/tests/test_grouping.py
@@ -485,6 +485,11 @@ class Grouping_Test(unittest.TestCase):
         goodresult = FA([0.0, 1.0, 2.0, 1.0, 2.0, 5.0, 6.0, 5.0, 8.0, 9.0])
         self.assertTrue(np.all(finalcalc == goodresult))
 
+        # try with filtered
+        c = Cat([1, 0, 1, 0], ['a'])
+        r = c.apply_nonreduce(np.cumsum, FA([10, 1, 20, 2]))
+        assert_array_equal(r[0], FA([10, 1, 30, 3]))
+
     def test_ema(self):
         arrsize = 100
         numrows = 20


### PR DESCRIPTION
Don't take the fast path if there are filtered entries in the index
Fixes #292
Fixes #170
Fixes #259