### PR TITLE
Correct data type for ismember return value in the case of empty inpu…

### DIFF
--- a/riptable/rt_numpy.py
+++ b/riptable/rt_numpy.py
@@ -782,7 +782,9 @@ def ismember(a, b, h=2, hint_size: int = 0, base_index: int = 0) -> Tuple[Union[
     is_multikey = False
 
     if len_a == 0 or len_b == 0:
-        return zeros(len(a), dtype=bool), full(len_a, INVALID_DICT[np.dtype(np.int32).num])
+        indexer_type = np.dtype(np.int32)
+        indexer = full(len_a, INVALID_DICT[indexer_type.num], dtype=indexer_type)
+        return zeros(len(a), dtype=bool), indexer
 
     if isinstance(a, TypeRegister.Categorical) or isinstance(b, TypeRegister.Categorical):
         if isinstance(a, TypeRegister.Categorical):

--- a/riptable/tests/test_ismember.py
+++ b/riptable/tests/test_ismember.py
@@ -524,5 +524,19 @@ def test_ismember_categorical_with_invalid():
     assert_array_equal(idx, expected_idx)
 
 
+@pytest.mark.parametrize('a, b, isin, indexer', [
+    (FA([0, 1, 2]), FA([]),
+     FastArray([False] * 3),
+     tile(INVALID_DICT[np.dtype('int32').num], 3).astype('int32')),
+
+    (FA([]), FA([0, 1, 2]), FA([], dtype=bool), FA([], dtype='int32')),
+])
+def test_ismember_type_for_empties(a, b, isin, indexer):
+    result = ismember(a, b)
+    assert_array_equal(isin, result[0])
+    assert_array_equal(indexer, result[1])
+    assert result[1].isna().all()
+
+
 if __name__ == "__main__":
     tester = unittest.main()


### PR DESCRIPTION
…ts. Currently the indexer is populated with int32 invalids but is of int64 type