### PR TITLE
rt.ismember requires lossless coercion

### DIFF
--- a/riptable/rt_numpy.py
+++ b/riptable/rt_numpy.py
@@ -283,8 +283,10 @@ def _find_lossless_common_type(dt1 : np.dtype, dt2 : np.dtype) -> Union[np.dtype
     """
     Finds the lossless common type, or None if not found.
     """
+    dtc = np.find_common_type([dt1, dt2], [])
+
     if not np.issubdtype(dt1, np.number) or not np.issubdtype(dt2, np.number):
-        return np.find_common_type([dt1, dt2], [])
+        return dtc
 
     def _get_info(dt):
         if np.issubdtype(dt, np.integer):
@@ -293,17 +295,14 @@ def _find_lossless_common_type(dt1 : np.dtype, dt2 : np.dtype) -> Union[np.dtype
         info = np.finfo(dt)
         return { 'min': info.min, 'max': info.max, 'prec': info.precision }
 
+    infoc = _get_info(dtc)
     info1 = _get_info(dt1)
     info2 = _get_info(dt2)
 
     def can_represent(itest, itarget):
         return itest['min'] >= itarget['min'] and itest['max'] <= itarget['max'] and itest['prec'] <= itarget['prec']
 
-    if can_represent(info1, info2):
-        return dt2
-    if can_represent(info2, info1):
-        return dt1
-    return None
+    return dtc if can_represent(info1, infoc) and can_represent(info2, infoc) else None
 
 
 def empty(shape, dtype: Union[str, np.dtype, type] = float, order: str = 'C') -> 'FastArray':

--- a/riptable/tests/test_ismember.py
+++ b/riptable/tests/test_ismember.py
@@ -1,4 +1,5 @@
 import unittest
+from numpy import dtype
 import pytest
 
 from numpy.testing import assert_array_equal
@@ -536,6 +537,31 @@ def test_ismember_type_for_empties(a, b, isin, indexer):
     assert_array_equal(isin, result[0])
     assert_array_equal(indexer, result[1])
     assert result[1].isna().all()
+
+@pytest.mark.parametrize('dt1, dt2, expected_failure', [
+    ('int32', 'float32', True),
+    ('uint8', 'int8', True),
+    ('uint64', 'int64', True),
+    ('uint8', 'float32', False),
+    ('int32', 'int64', False),
+    ('int32', 'float64', False),
+    ('uint64', 'str', True),
+])
+def test_ismember_lossless_check(dt1, dt2, expected_failure):
+    def default_value(dt):
+        return 0 if np.issubdtype(dt, np.number) else ''
+    fa1 = FA([default_value(dt1)], dtype=dt1)
+    fa2 = FA([default_value(dt2)], dtype=dt2)
+
+    actual_failure = False
+    try: ismember(fa1, fa2)
+    except TypeError: actual_failure = True
+    assert actual_failure == expected_failure
+
+    actual_failure = False
+    try: ismember(fa2, fa1)
+    except TypeError: actual_failure = True
+    assert actual_failure == expected_failure
 
 
 if __name__ == "__main__":

--- a/riptable/tests/test_ismember.py
+++ b/riptable/tests/test_ismember.py
@@ -539,10 +539,11 @@ def test_ismember_type_for_empties(a, b, isin, indexer):
     assert result[1].isna().all()
 
 @pytest.mark.parametrize('dt1, dt2, expected_failure', [
-    ('int32', 'float32', True),
-    ('uint8', 'int8', True),
+    ('int32', 'float32', False),
+    ('uint8', 'int8', False),
     ('uint64', 'int64', True),
     ('uint8', 'float32', False),
+    ('int16', 'int64', False),
     ('int32', 'int64', False),
     ('int32', 'float64', False),
     ('uint64', 'str', True),


### PR DESCRIPTION
The `rt.ismember()` function requires lossless coercion of both input dtypes into a common type. Since the common type chosen by numpy does not guarantee lossless coercion, add tests for that.