### PR TITLE
Improve test run scripts

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master,improve-test-run-scripts ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,8 @@ jobs:
           python -m riptable.tests.run
       - name: Tooling integration tests
         run: |
-          ipython -m riptable.test_tooling_integration.run
+          echo "DISABLED until tooling tests can be updated"
+          #ipython -m riptable.test_tooling_integration.run
       # disable hypothesis tests until they run faster, are more consistent, and are easier to investigate
       #- name: Property based hypothesis tests
       #  run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ master,improve-test-run-scripts ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019]
-        #python-version: [3.8, 3.9, '3.10']
-        python-version: [3.9]
+        python-version: [3.8, 3.9, '3.10']
         numpy-version: [1.21]
     steps:
       - name: Checkout repo
@@ -95,9 +94,6 @@ jobs:
           twine upload dist/* --verbose
 
   conda_build:
-    #+DEL
-    if: ${{ false }}
-    #-DEL
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2019]
-        python-version: [3.8, 3.9, '3.10']
+        #python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9]
         numpy-version: [1.21]
     steps:
       - name: Checkout repo
@@ -47,10 +48,10 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest riptable/tests
+          python -m riptable.tests.run
       - name: Tooling integration tests
         run: |
-          ipython -m pytest riptable/test_tooling_integration
+          ipython -m riptable.test_tooling_integration.run
       # disable hypothesis tests until they run faster, are more consistent, and are easier to investigate
       #- name: Property based hypothesis tests
       #  run: |
@@ -93,6 +94,9 @@ jobs:
           twine upload dist/* --verbose
 
   conda_build:
+    #+DEL
+    if: ${{ false }}
+    #-DEL
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/riptable/test_tooling_integration/ipykernel_integration_test.py
+++ b/riptable/test_tooling_integration/ipykernel_integration_test.py
@@ -86,7 +86,7 @@ def get_matches(code_text: str, complete_text: str) -> List[str]:
         assert reply['status'] == 'ok'
         wait_for_idle(kc)
         kc.complete(complete_text)
-        reply = kc.get_shell_msg(block=True, timeout=TIMEOUT)
+        reply = kc.get_shell_msg(timeout=TIMEOUT)
         matches = reply['content']['matches']
     return matches
 

--- a/riptable/test_tooling_integration/run.py
+++ b/riptable/test_tooling_integration/run.py
@@ -1,0 +1,26 @@
+# $Id$
+
+import pytest
+import sys
+import os
+
+
+def run_all(extra_args=None):
+    """
+    Run all the tooling integration tests of riptable.
+
+    Parameters
+    ----------
+    extra_args : list
+        List of extra arguments (e.g. ['--verbosity=3'])
+    """
+    if extra_args is None:
+        extra_args = []
+    return pytest.main(extra_args + ['-k', 'test_', os.path.dirname(__file__)])
+
+
+# Usage: "ipython -m riptable.test_tooling_integration.run"
+# You can add more arguments to the pytest, like "ipython -m riptable.test_tooling_integration.run --verbosity=2"
+if __name__ == "__main__":
+    # Force ipython to exit with the exit code, as sys.exit() is caught and ignored :-/
+    os._exit(run_all(sys.argv[1:]))

--- a/riptable/tests/run.py
+++ b/riptable/tests/run.py
@@ -16,10 +16,10 @@ def run_all(extra_args=None):
     """
     if extra_args is None:
         extra_args = []
-    pytest.main(extra_args + ['-k', 'test_', os.path.dirname(__file__)])
+    return pytest.main(extra_args + ['-k', 'test_', os.path.dirname(__file__)])
 
 
 # Usage: "python -m riptable.tests.run"
 # You can add more arguments to the pytest, like "python -m riptable.tests.run --verbosity=2"
 if __name__ == "__main__":
-    run_all(sys.argv[1:])
+    sys.exit(run_all(sys.argv[1:]))


### PR DESCRIPTION
Improve the run scripts so they will propagate exit codes. This allows them to break the build if tests fail.
Disable the tooling integration tests since they actually fail, and will now fail the builds. This will need to be remedied (issue #313).
