### PR TITLE
v1.7.0

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - riptide_cpp >=1.12.1,<2 # run with any (compatible) version in this range
+    - riptide_cpp >=1.12.2,<2 # run with any (compatible) version in this range
     - pandas >=1.0,<3.0
     - ansi2html >=1.5.2
     - numpy >=1.22

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -17,9 +17,8 @@ requirements:
   run:
     - python
     - riptide_cpp >=1.12.1,<2 # run with any (compatible) version in this range
-    - pandas >=0.24,<2.0
+    - pandas >=1.0,<3.0
     - ansi2html >=1.5.2
-    - ipykernel
     - numpy >=1.22
     - numba >=0.56.2
     - python-dateutil

--- a/dev_tools/gen_requirements.py
+++ b/dev_tools/gen_requirements.py
@@ -97,6 +97,11 @@ sphinx_reqs = (
     + tests_reqs
 )
 
+# Black formatting requirements.
+black_reqs = [
+    "black==22.*",
+]
+
 # Docstrings validation requirements.
 # Validation requires complete riptable for iteration and evaluating examples.
 docstrings_reqs = (
@@ -105,14 +110,10 @@ docstrings_reqs = (
         "tomli",
     ]
     + flake8_reqs
+    + black_reqs
     + runtime_reqs
     + tests_reqs
 )
-
-# Black formatting requirements.
-black_reqs = [
-    "black==22.*",
-]
 
 # Pydocstyle doc style requirements.
 pydocstyle_reqs = [

--- a/dev_tools/gen_requirements.py
+++ b/dev_tools/gen_requirements.py
@@ -13,6 +13,11 @@ def is_windows() -> bool:
     return platform.system() == "Windows"
 
 
+def is_python(major: int, minor: int) -> bool:
+    ver = sys.version_info
+    return ver.major == major and ver.minor == minor
+
+
 _ABSEIL_REQ = "abseil-cpp==20220623.*"
 _BENCHMARK_REQ = "benchmark>=1.7,<1.8"
 _NUMPY_REQ = "numpy>=1.22"
@@ -53,10 +58,9 @@ pypi_reqs = [
 runtime_reqs = [
     # No riptide_cpp as that must be handled separately
     "ansi2html>=1.5.2",
-    "ipykernel",
     "numba>=0.56.2",
     _NUMPY_REQ,
-    "pandas>=0.24,<2.0",
+    "pandas>=1.0,<3.0",
     "python-dateutil",
     _TBB_REQ,
 ]
@@ -72,7 +76,8 @@ tests_reqs = [
     "bokeh",
     "bottleneck",
     "hypothesis",
-    "ipython",
+    "ipykernel",
+    "ipython<8.13" if is_python(3, 8) else "ipython",
     "matplotlib",
     "nose",
     "pyarrow",

--- a/docs/source/tutorial/tutorial.rst
+++ b/docs/source/tutorial/tutorial.rst
@@ -33,5 +33,6 @@ Appendix
    
    tutorial_numpy_rt
    tutorial_cat_reduce
+   tutorial_cat_adv_instantiation
    
    

--- a/docs/source/tutorial/tutorial_cat_adv_instantiation.rst
+++ b/docs/source/tutorial/tutorial_cat_adv_instantiation.rst
@@ -1,0 +1,131 @@
+
+A Useful Way to Instantiate a Categorical
+*****************************************
+
+It can sometimes be useful to instantiate a Categorical with only one
+category, then fill it in as needed.
+
+For example, let’s say we have a Dataset with a column that has a lot of
+categories, and we want to create a new Categorical column that keeps
+two of those categories, properly aligned with the rest of the data in
+the Dataset, and lumps the other categories into a category called
+‘Other.’
+
+Our Dataset, with a column of many categories::
+
+    >>> rng = np.random.default_rng(seed=42)
+    >>> N = 50
+    >>> ds_buildcat = rt.Dataset({'big_cat': rng.choice(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'], N)})
+    >>> ds_buildcat
+      #   big_cat
+    ---   -------
+      0   D      
+      1   I      
+      2   A      
+      3   I      
+      4   F      
+      5   B      
+      6   D      
+      7   F      
+      8   D      
+      9   B      
+     10   G      
+     11   G      
+     12   B      
+     13   C      
+     14   C      
+    ...   ...    
+     35   I      
+     36   J      
+     37   D      
+     38   C      
+     39   J      
+     40   G      
+     41   C      
+     42   G      
+     43   F      
+     44   J      
+     45   C      
+     46   J      
+     47   J      
+     48   B      
+     49   B    
+
+We create our ‘small’ Categorical instantiated with 3s, which fills the
+column with the ‘Other’ category::
+
+    >>> ds_buildcat.small_cat = rt.Cat(rt.full(ds_buildcat.shape[0], 3), categories=['B', 'D', 'Other']) 
+    >>> ds_buildcat.small_cat
+    >>> ds_buildcat
+      #   big_cat   small_cat
+    ---   -------   ---------
+      0   D         Other    
+      1   I         Other    
+      2   A         Other    
+      3   I         Other    
+      4   F         Other    
+      5   B         Other    
+      6   D         Other    
+      7   F         Other    
+      8   D         Other    
+      9   B         Other    
+     10   G         Other    
+     11   G         Other    
+     12   B         Other    
+     13   C         Other    
+     14   C         Other    
+    ...   ...       ...      
+     35   I         Other    
+     36   J         Other    
+     37   D         Other    
+     38   C         Other    
+     39   J         Other    
+     40   G         Other    
+     41   C         Other    
+     42   G         Other    
+     43   F         Other    
+     44   J         Other    
+     45   C         Other    
+     46   J         Other    
+     47   J         Other    
+     48   B         Other    
+     49   B         Other  
+
+Now we can fill in the aligned ‘B’ and ‘D’ categories::
+
+    >>> ds_buildcat.small_cat[ds_buildcat.big_cat == 'B'] = 'B'
+    >>> ds_buildcat.small_cat[ds_buildcat.big_cat == 'D'] = 'D'
+    >>> ds_buildcat
+      #   big_cat   small_cat
+    ---   -------   ---------
+      0   D         D        
+      1   I         Other    
+      2   A         Other    
+      3   I         Other    
+      4   F         Other    
+      5   B         B        
+      6   D         D        
+      7   F         Other    
+      8   D         D        
+      9   B         B        
+      10  G         Other    
+      11  G         Other    
+      12  B         B        
+      13  C         Other    
+      14  C         Other    
+     ...  ...       ...      
+      35  I         Other    
+      36  J         Other    
+      37  D         D        
+      38  C         Other    
+      39  J         Other    
+      40  G         Other    
+      41  C         Other    
+      42  G         Other    
+      43  F         Other    
+      44  J         Other    
+      45  C         Other    
+      46  J         Other    
+      47  J         Other    
+      48  B         B        
+      49  B         B  

--- a/riptable/rt_bin.py
+++ b/riptable/rt_bin.py
@@ -1,6 +1,7 @@
 __all__ = ["cut", "qcut", "quantile"]
 
 from typing import (
+    Literal,
     Optional,
 )
 
@@ -417,6 +418,7 @@ def cut(
     precision=3,
     include_lowest=False,
     filter: Optional[np.ndarray] = None,
+    duplicates: Literal["raise", "drop"] = "raise",
 ):
     """
     Bin values into discrete intervals.
@@ -560,7 +562,14 @@ def cut(
     labels = None if labels is True else labels
 
     fac, bins, ret_labels = _bins_to_cuts_new(
-        x, bins, right=right, labels=labels, precision=precision, include_lowest=include_lowest, dtype=dtype
+        x,
+        bins,
+        right=right,
+        labels=labels,
+        precision=precision,
+        include_lowest=include_lowest,
+        dtype=dtype,
+        duplicates=duplicates,
     )
 
     labels = ret_labels if labels is not False else labels

--- a/riptable/rt_bin.py
+++ b/riptable/rt_bin.py
@@ -421,92 +421,164 @@ def cut(
     duplicates: Literal["raise", "drop"] = "raise",
 ):
     """
-    Bin values into discrete intervals.
+    Partition values into discrete bins.
 
-    Use `cut` when you need to segment and sort data values into bins. This
-    function is also useful for going from a continuous variable to a
-    categorical variable. For example, `cut` could convert ages to groups of
-    age ranges. Supports binning into an equal number of bins or a
-    pre-specified array of bins.
+    This function is also useful for converting a continuous variable to a
+    `.Categorical` variable.
+
+    Values can be partitioned into a specified number of equal-width bins
+    or bins bounded by specified endpoints.
+
+    For bins bounded by specified endpoints, values that fall outside of the
+    bin range are put into the 'Filtered' bin, which is mapped to 0 in the
+    returned `.Categorical`. See the exception (caused by a known issue) noted
+    in the description of the `right` parameter, below.
+
+    Other known issues are noted in the parameter descriptions and shown in the
+    Examples section, below.
 
     Parameters
     ----------
-    x : array-like
-        The input array to be binned. Must be 1-dimensional.
-    bins : int, sequence of scalars
-        The criteria to bin by:
-            * int: Defines the number of equal-width bins in the range of `x`.
-              The range of `x` is extended by .1% on each side to include the minimum
-              and maximum values of `x`.
-            * sequence of scalars: Defines the bin edges allowing for non-uniform width.
-              No extension of the range of `x` is done.
-    right : bool, default True
-        Indicates whether `bins` includes the rightmost edge or not. If
-        ``right == True`` (the default), then the `bins` ``[1, 2, 3, 4]``
-        indicate (1,2], (2,3], (3,4].
-    labels : boolean, array, or None
-        Specifies the labels for the returned bins. If an array, must be the same
-        length as the resulting bins. If False, returns only integer indicators of the
-        bins. If None or True, the labels are created based on the bins.
-        This affects the type of the output container (see below).
-    retbins : bool, default False
-        Whether to return the bins or not. Useful when bins is provided
-        as a scalar.
+    x : `array`
+        The input array to be partitioned. Must be 1-dimensional. NaN values are
+        put into the 'Filtered' bin.
+    bins : `int` or sequence of scalar
+        Determines how bins are created:
+
+            - `int`: Creates `int` number of equal-width bins in the range of `x`.
+            - sequence of scalar: Creates bins based on the specified endpoints.
+              Bins can be of non-uniform width.
+    right : `bool`, default `True`
+        Indicates whether each bin includes its right endpoint or not.
+        Note: Until known issues are fixed:
+
+        - Each bin includes its right endpoint, even if `right` is set to `False`.
+        - If `right` is `True` (the default), the first bin includes its left
+          endpoint even if `include_lowest` is `False` (the default).
+        - If `right` is `False`, values of `x` that fall outside of the last
+          bin's right endpoint are put into a bin labeled with an integer representing
+          the bin number. For example, if ``bins=[1, 2, 3, 4]``, a value of 5
+          in `x` is put in a bin labeled ``!<4>``. This bin is mapped to 4 in
+          the integer mapping array.
+    labels : `bool`, `array`, or `None`, default `True`
+        Specify the labels for the returned bins. If an array, it must be the
+        same length as the number of resulting bins (that is, its length should
+        be one fewer than the number of endpoints). If `True` (the default) or
+        `None`, the labels are created based on the bin endpoints. If `False`,
+        only a `.FastArray` of the integer bin mappings is returned.
+    retbins : `bool`, default `False`
+        Whether to return an array of the bin endpoints. Useful when `bins`
+        is provided as a scalar or other labels are specified. See the Returns
+        section below for details of the output.
     precision : int, default 3
-        The precision at which to store and display the bins labels.
-    include_lowest : bool, default False
-        Whether the first interval should be left-inclusive or not.
-    filter: ndarray of bool, default None
-        If provided, any False values will be ignored in the calculation.
+        The precision at which to display the bin labels. Note that the
+        endpoints used for partitioning are not changed.
+    include_lowest : `bool`, default `False`
+        Indicates whether the first bin should include its left endpoint
+        or not. Note: Until a known issue is fixed, the first bin always
+        includes its left endpoint, except when `right` is set to `False`.
+    filter: `array` of `bool`, optional
+        A boolean mask array. If a filter is provided, any values of `x`
+        corresponding to `False` values are put in the 'Filtered' bin and mapped
+        to 0 in the integer bin mapping array. Note that until a known issue
+        is fixed, this parameter accepts a mask array that is shorter than `x`
+        and ignores values of `x` that are past the last corresponding value of
+        the mask.
+    duplicates : {'raise', 'drop'}, default 'raise'
+        If bin endpoints are not unique, raise an error or drop duplicate values.
 
     Returns
     -------
-    out : Categorical or FastArray
-        An array-like object representing the respective bin for each value
-        of `x`. The type depends on the value of `labels`:
+    bins : Categorical or FastArray
+        - If `labels` is `True` or `None`, a `.Categorical` is returned,
+          consisting of the bins, the integer mapping codes for the bins, and
+          the unique bin labels.
+        - If `labels` is `False`, a `.FastArray` is returned that contains the
+          integer mapping codes.
 
-        * False : returns a FastArray of integers
-        * array, True, or None : returns a Categorical
-    bins : ndarray of floats
-        The computed or specified bins. Only returned when `retbins=True`.
+    endpoints (optional) : `~numpy.ndarray` of str
+        An array of the bin endpoints. Returned as a separate value, only
+        when `retbins` is `True`.
 
     See Also
     --------
-    :meth:`~rt.rt_bin.qcut` :
-        Discretize variable into equal-sized buckets based on rank or based on sample quantiles.
-    :class:`~rt.rt_categorical.Categorical` :
-        Array type for storing data that come from a fixed set of values.
+    riptable.qcut :
+        Partition values into bins based on rank or sample quantiles.
 
     Examples
     --------
-    Discretize into three equal-sized bins.
+    Partition values into three equal-sized bins.
 
-    >>> rt.cut(np.array([1, 7, 5, 4, 6, 3]), 3)
+    >>> rt.cut(x=rt.FA([1, 7, 5, 4, 6, 3]), bins=3)
     Categorical([1.0->3.0, 5.0->7.0, 3.0->5.0, 3.0->5.0, 5.0->7.0, 1.0->3.0]) Length: 6
       FastArray([1, 3, 2, 2, 3, 1], dtype=int8) Base Index: 1
       FastArray([b'1.0->3.0', b'3.0->5.0', b'5.0->7.0'], dtype='|S8') Unique count: 3
 
-    Also return the bins.
+    Also return an array of the bin endpoints.
 
-    >>> rt.cut(np.array([1, 7, 5, 4, 6, 3]), 3, retbins=True)
-    (Categorical([1.0->3.0, 5.0->7.0, 3.0->5.0, 3.0->5.0, 5.0->7.0, 1.0->3.0]) Length: 6
+    >>> cat, endpoints = rt.cut(x=rt.FA([1, 7, 5, 4, 6, 3]), bins=3, retbins=True)
+    >>> cat
+    Categorical([1.0->3.0, 5.0->7.0, 3.0->5.0, 3.0->5.0, 5.0->7.0, 1.0->3.0]) Length: 6
       FastArray([1, 3, 2, 2, 3, 1], dtype=int8) Base Index: 1
-      FastArray([b'1.0->3.0', b'3.0->5.0', b'5.0->7.0'], dtype='|S8') Unique count: 3,
-     array([1., 3., 5., 7.]))
+      FastArray([b'1.0->3.0', b'3.0->5.0', b'5.0->7.0'], dtype='|S8') Unique count: 3
+    >>> endpoints
+    array([1., 3., 5., 7.])
 
-    Return just an array of integers.
+    Return just the array of integer bin mappings.
 
-    >>> rt.cut(np.array([1, 7, 5, 4, 6, 3]), 3, labels=False)
+    >>> rt.cut(x=rt.FA([1, 7, 5, 4, 6, 3]), bins=3, labels=False)
     FastArray([1, 3, 2, 2, 3, 1], dtype=int8)
 
-    Discovers the same bins, but assign them specific labels. Notice that
-    the returned Categorical's categories are `labels` and it is ordered.
+    Assign the bins specific labels. Notice that the returned `.Categorical`
+    object's categories are `labels`.
 
-    >>> rt.cut(np.array([1, 7, 5, 4, 6, 3]),
-    ...        3, labels=["bad", "medium", "good"])
+    >>> rt.cut(x=rt.FA([1, 7, 5, 4, 6, 3]),
+    ...        bins=3, labels=["bad", "medium", "good"])
     Categorical([bad, good, medium, medium, good, bad]) Length: 6
       FastArray([1, 3, 2, 2, 3, 1], dtype=int8) Base Index: 1
       FastArray([b'bad', b'medium', b'good'], dtype='|S6') Unique count: 3
+
+    Partition values into bins with specified endpoints. Values that fall outside
+    of the bins are put in the 'Filtered' category.
+
+    >>> rt.cut(x=rt.FA([1, 7, 5, 4, 6, 3]), bins=[1, 3, 6])
+    Categorical([1.0->3.0, Filtered, 3.0->6.0, 3.0->6.0, 3.0->6.0, 1.0->3.0]) Length: 6
+      FastArray([1, 0, 2, 2, 2, 1], dtype=int8) Base Index: 1
+      FastArray([b'1.0->3.0', b'3.0->6.0'], dtype='|S8') Unique count: 2
+
+    **Known Issues**
+
+    Each bin includes its right endpoint, even if `right` is set to `False`.
+
+    >>> rt.cut(x=rt.FA([2, 3, 4]), bins=[1, 2, 3, 4], right=False)
+    Categorical([1.0->2.0, 2.0->3.0, 3.0->4.0]) Length: 3
+      FastArray([1, 2, 3], dtype=int8) Base Index: 1
+      FastArray([b'1.0->2.0', b'2.0->3.0', b'3.0->4.0'], dtype='|S8') Unique count: 3
+
+    If `right` is `True` (the default), the first bin includes its left endpoint
+    even if `include_lowest` is `False` (the default).
+
+    >>> rt.cut(x=rt.FA([1, 2, 3, 4]), bins=3, include_lowest=False)
+    Categorical([1.0->2.0, 1.0->2.0, 2.0->3.0, 3.0->4.0]) Length: 4
+      FastArray([1, 1, 2, 3], dtype=int8) Base Index: 1
+      FastArray([b'1.0->2.0', b'2.0->3.0', b'3.0->4.0'], dtype='|S8') Unique count: 3
+
+    If `right` is `False`, values of `x` that fall outside of the last bin's
+    right endpoint are put into a bin labeled with an integer representing
+    the bin number.
+
+    >>> rt.cut(x=rt.FA([1, 2, 3, 4, 5, 6]), bins=[1, 2, 3, 4], right=False)
+    Categorical([Filtered, 1.0->2.0, 2.0->3.0, 3.0->4.0, !<4>, !<4>]) Length: 6
+      FastArray([0, 1, 2, 3, 4, 4], dtype=int8) Base Index: 1
+      FastArray([b'1.0->2.0', b'2.0->3.0', b'3.0->4.0'], dtype='|S8') Unique count: 3
+
+    If a boolean mask filter is provided that's shorter than the length of `x`,
+    values of `x` that are past the length of the mask are ignored.
+
+    >>> rt.cut(x=rt.FA([1, 2, 3, 4]), bins=2, filter=rt.FA([False, True, True]))
+    Categorical([Filtered, 2.0->2.5, 2.5->3.0]) Length: 3
+      FastArray([0, 1, 2], dtype=int8) Base Index: 1
+      FastArray([b'2.0->2.5', b'2.5->3.0'], dtype='|S8') Unique count: 2
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
 

--- a/riptable/rt_dataset.py
+++ b/riptable/rt_dataset.py
@@ -6938,14 +6938,18 @@ class Dataset(Struct):
         func: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         zeros: bool = True,
         nans: bool = True,
+        columns: bool = True,
         rows: bool = True,
         keep: bool = False,
         ret_filters: bool = False,
     ) -> Union["Dataset", Tuple["Dataset", np.ndarray, np.ndarray]]:
         """
-        Returns a Dataset with columns removed that contain all zeros or all nans (or either).
+        Returns a Dataset with columns and/or rows removed that contain all zeros and/or nans.
+        Whether to remove only zeros, only nans, or both zeros and nans is controlled by kwargs `zeros` and `nans`.
 
-        If `rows` is True (the default), any rows which are all zeros or all nans will also be removed.
+        If `columns` is True (the default), any columns which are all zeros and/or nans will be removed.
+
+        If `rows` is True (the default), any rows which are all zeros and/or nans will be removed.
 
         If `func` is set, it will bypass the zeros and nan check and instead call `func`.
 
@@ -6962,8 +6966,10 @@ class Dataset(Struct):
             Defaults to True. Values must be non-zero.
         nans : bool
             Defaults to True. Values cannot be nan.
+        columns : bool
+            Defaults to True. Reduce columns if entire column filtered.
         rows : bool
-            Defaults to True. Reduce rows also if entire row filtered.
+            Defaults to True. Reduce rows if entire row filtered.
         keep : bool
             Defaults to False.  When set to True, does the opposite.
         ret_filters : bool
@@ -7026,7 +7032,8 @@ class Dataset(Struct):
                         # print('**col ', col, sum(result), len(arr))
                         addcol = sum(result) != len(arr)
 
-                    if addcol:
+                    # add if not all TRUE/FALSE or if columns == False (to add all columms)
+                    if addcol or not columns:
                         col_filter_mask.append(result)
                         col_filter.append(col)
                         colboolmask[i] = True

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -1046,7 +1046,33 @@ class FastArray(np.ndarray):
     @property
     def _np(self) -> np.ndarray:
         """
-        quick way to return a numpy array instead of fast array
+        Return a NumPy array view of the input `FastArray`.
+
+        Returns
+        -------
+        numpy.ndarray
+            A NumPy array view of the input `FastArray`.
+
+        See Also
+        --------
+        Fastarray.view : View a NumPy array as a `FastArray`.
+
+        Examples
+        --------
+        Return a NumPy array view for an integer `FastArray`:
+
+        >>> a = rt.FA([1, 2, 3, 4, 5])
+        >>> a
+        FastArray([1, 2, 3, 4, 5])
+        >>> a._np
+        array([1, 2, 3, 4, 5])
+
+        Update the `FastArray` using the NumPy array view:
+
+        >>> npview = a._np
+        >>> npview[2] = 10
+        >>> a
+        FastArray([ 1,  2, 10,  4,  5])
         """
         return self.view(np.ndarray)
 
@@ -1387,6 +1413,40 @@ class FastArray(np.ndarray):
 
     # --------------------------------------------------------------------------
     def copy(self, order="K") -> FastArray:
+        """
+        Return a copy of the input `FastArray`.
+
+        Parameters
+        ----------
+        order : {'K', 'C', 'F', 'A'}, default 'K'
+            Controls the memory layout of the copy: 'K' means match the layout of the input array as closely as possible;
+            'C' means row-based (C-style) order; 'F' means column-based (Fortran-style) order;
+            'A' means 'F' if the input array is formatted as 'F', 'C' if not.
+
+        Returns
+        -------
+        FastArray
+            A copy of the input `FastArray`.
+
+        See Also
+        --------
+        .Categorical.copy : Returns a copy of the input `.Categorical`.
+        .Dataset.copy : Returns a copy of the input `.Dataset`.
+        .Struct.copy : Returns a copy of the input `.Struct`.
+
+        Examples
+        --------
+        Copy a `FastArray`:
+
+        >>> a = rt.FA([1, 2, 3, 4, 5])
+        >>> a
+        FastArray([1, 2, 3, 4, 5])
+        >>> a2 = a.copy()
+        >>> a2
+        FastArray([1, 2, 3, 4, 5])
+        >>> a2 is a
+        False  # The copy is a separate object.
+        """
         # result= super(FastArray, self).copy(order)
         if self.flags.f_contiguous or self.flags.c_contiguous:
             if order == "K" and self.dtype.num <= 13:
@@ -1569,28 +1629,43 @@ class FastArray(np.ndarray):
     # -------------------------------------------------------------------------
     def between(self, low, high, include_low: bool = True, include_high: bool = False) -> FastArray:
         """
-        Determine which elements of the array are in a a given interval.
-
-        Return a boolean mask indicating which elements are between `low` and `high` (including/excluding endpoints
-        can be controlled by the `include_low` and `include_high` arguments).
-
-        Default behaviour is equivalent to (self >= low) & (self < high).
+        Return a boolean `FastArray` indicating which input values are in a specified interval.
 
         Parameters
         ----------
-        low: scalar, array_like
-            Lower bound for test interval.  If array, should have the same size as `self` and comparisons are done elementwise.
-        high: scalar, array_like
-            Upper bound for test interval.  If array, should have the same size as `self` and comparisons are done elementwise.
-        include_low: bool
-            Should the left endpoint included in the test interval
-        include_high: bool
-            Should the right endpoint included in the test interval
+        low: scalar, array
+            Lower bound for the interval. If an array, must be the same size as `self`, and comparisons are done elementwise.
+        high: scalar, array
+            Upper bound for the interval. If an array, must be the same size as `self`, and comparisons are done elementwise.
+        include_low: bool, default True
+            Specifies whether `low` is included when performing comparisons.
+        include_high: bool, default False
+            Specifies whether `high` is included when performing comparisons.
 
         Returns
         -------
-        array_like[bool]
-            An boolean mask indicating if the associated elements are in the test interval
+        FastArray
+            A boolean `FastArray` indicating which input values are in a specified interval.
+
+        Examples
+        --------
+        Specify an interval using scalars:
+
+        >>> a = rt.FA([9, 2, 3, 5, 8, 9, 1, 4, 6])
+        >>> a.between(5, 9, include_low=False)  # Exclude `5` (left endpoint)
+        FastArray([False, False, False, False,  True, False, False, False,  True])
+
+        Specify an interval using arrays:
+
+        >>> a2 = rt.FA([1, 2, 3, 4, 5])
+        >>> a2.between([1, 3, 5, 5, 5], [2, 4, 6, 6, 6])
+        FastArray([ True, False, False, False,  True])
+
+        Specify an interval mixing scalar and array bounds:
+
+        >>> a3 = rt.FA([1, 2, 3, 4, 5])
+        >>> a3.between(2, [2, 4, 6, 6, 6])
+        FastArray([False,  True,  True,  True,  True])
         """
         low = asanyarray(low)
         high = asanyarray(high)
@@ -1613,30 +1688,100 @@ class FastArray(np.ndarray):
         seed: Optional[Union[int, Sequence[int], np.random.SeedSequence, np.random.Generator]] = None,
     ) -> FastArray:
         """
+        Return a given number of randomly selected values from a `FastArray`.
+
+        Parameters
+        ----------
+        N : int, default 10
+            Number of values to select. The entire array is returned if `N` is greater than the size of the array.
+        filter : array (bool or int), optional
+            A boolean mask or index array to filter values before selection. Note that until a reported bug is fixed, no error is raised and unexpected results may occur when a boolean mask array with a length different from that of the array it's masking is passed as a filter.
+        seed : int or other types, optional
+            A seed to initialize the random number generator. If one is not provided, the generator is initialized using random data from the OS. For details and other accepted types, see the `seed` parameter for `numpy.random.default_rng`.
+
+        Returns
+        -------
+        FastArray
+            A new `FastArray` containing the randomly selected values.
+
+        See Also
+        --------
+        .Dataset.sample : Return a specified number of randomly selected rows from a `.Dataset`.
+
         Examples
         --------
-        >>> a=rt.arange(10)
+        No sample size specified:
+
+        >>> a = rt.FA([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        >>> a.sample()  # 10 randomly selected values returned.
+        FastArray([ 1,  2,  3,  4,  5,  6,  7,  9, 10, 11])  # Random
+
+        Sample 3 values:
+
+        >>> a = rt.FA([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
         >>> a.sample(3)
-        FastArray([0, 4, 9])
+        FastArray([1, 4, 9])  # Random
+
+        Specify a sample size larger than the array:
+
+        >>> a2 = rt.FA([1, 2, 3, 4, 5])
+        >>> a2.sample(100)  # The entire array is returned.
+        FastArray([1, 2, 3, 4, 5])
+
+        Specify an index array for filtering:
+
+        >>> a3 = rt.FA(['TSLA','AMZN','IBM', 'SPY', 'GME', 'AAPL', 'FB', 'GOOG', 'MSFT', 'UBER'])  # Create sample data.
+        >>> filter = rt.FA([0, 1, 3, 7])  # Specify indices of a3 to take the sample from.
+        >>> a3.sample(2, filter)
+        FastArray([b'TSLA', b'GOOG'], dtype='|S4')  # Random
+
+        Specify a boolean mask array for filtering:
+
+        >>> a3.sample(8, filter=rt.FA(a3 != 'SPY'))
+        FastArray([b'TSLA', b'IBM', b'GME', b'AAPL', b'FB', b'GOOG', b'MSFT',
+                   b'UBER'], dtype='|S4')  # Random
         """
         return sample(self, N=N, filter=filter, seed=seed)
 
     # --------------------------------------------------------------------------
     def duplicated(self, keep="first", high_unique=False) -> FastArray:
         """
-        See pandas.Series.duplicated
-
-        Duplicated values are indicated as True values in the resulting
-        FastArray. Either all duplicates, all except the first or all except the
-        last occurrence of duplicates can be indicated.
+        Return a boolean `FastArray` indicating `True` for duplicate items in the input array.
 
         Parameters
         ----------
-        keep : {'first', 'last', False}, default 'first'
-            - 'first' : Mark duplicates as True except for the first occurrence.
-            - 'last' : Mark duplicates as True except for the last occurrence.
-            - False : Mark values with just one occurrence as False.
+        keep : {'first', 'last', 'False'}, default 'first'
+            - 'first' : Mark each duplicate as `True` except for the first occurrence.
+            - 'last' : Mark each duplicate as `True` except for the last occurrence.
+            - 'False' : Mark all duplicates as `True`.
+        high_unique : bool, default `False` (hashing)
+            Controls whether the function uses hashing- or sorting-based logic to find unique values in the input array.
+            If your data has a high proportion of unique values, set to `True` for faster performance.
 
+        Returns
+        -------
+        FastArray
+            A boolean `FastArray` indicating `True` for duplicate items in the input array.
+
+        See Also
+        --------
+        FastArray.nunique : Returns the number of unique values in an array.
+        .Dataset.duplicated : Returns a boolean `FastArray` indicating `True` for duplicate rows.
+
+        Examples
+        --------
+        Exclude the first occurrence of each duplicate (use the default `keep` value):
+
+        >>> a = rt.FA([1, 2, 3, 4, 2, 7, 8, 8, 3])
+        >>> a
+        FastArray([1, 2, 3, 4, 2, 7, 8, 8, 3])
+        >>> a.duplicated()
+        FastArray([False, False, False, False,  True, False, False,  True,  True])
+
+        Mark all duplicates:
+
+        >>> a.duplicated(keep=False)
+        FastArray([False,  True,  True, False,  True, False,  True,  True,  True])
         """
         arr = self
 
@@ -3520,28 +3665,43 @@ class FastArray(np.ndarray):
     # -------------------------------------------------------
     def nunique(self) -> int:
         """
-        Returns number of unique values in array. Does not include nan or sentinel values in the count.
+        Return the number of unique values in the input `FastArray`. Does not include NaN or sentinel values.
+
+        Returns
+        -------
+        int
+            Number of unique values in the input `FastArray`. Does not include NaN or sentinel values.
+
+        See Also
+        --------
+        FastArray.duplicated : Returns a boolean `FastArray` indicating duplicate values.
+        .Categorical.nunique : Returns the number of unique values that occur in the `.Categorical`.
 
         Examples
         --------
-        Float with nan:
+        Retrieve the number of unique values in a floating point `FastArray`:
 
-        >>> a = FastArray([1.,2.,3.,np.nan])
+        >>> a = rt.FastArray([1., 2., 3., 1., 2., 3.])
+        >>> a
+        FastArray([1., 2., 3., 1., 2., 3.])
         >>> a.nunique()
         3
 
-        Signed integer with sentinel:
+        Retrieve the number of unique values in a floating point `FastArray` with a NaN value:
 
-        >>> a = FastArray([-128, 2, 3], dtype=np.int8)
-        >>> a.nunique()
+        >>> a2 = rt.FastArray([1., 2., 3., 1., 2., 3., rt.nan])
+        >>> a2
+        FastArray([ 1.,  2.,  3.,  1.,  2.,  3., nan])
+        >>> a2.nunique()  # The NaN value is not included.
+        3
+
+        Retrieve the number of unique values in an unsigned integer `FastArray` with a sentinel value:
+
+        >>> a3 = rt.FastArray([255, 2, 3, 2, 3], dtype="uint8")
+        >>> a3
+        FastArray([255,   2,   3,   2,   3], dtype=uint8)
+        >>> a3.nunique()  # The sentinel value is not included.
         2
-
-        Unsigned integer with sentinel:
-
-        >>> a = FastArray([255, 2, 3], dtype=np.uint8)
-        >>> a.nunique()
-        2
-
         """
         un = unique(self)
         count = len(un)
@@ -3612,27 +3772,44 @@ class FastArray(np.ndarray):
     # ---------------------------------------------------------------------------
     def shift(self, periods=1, invalid=None) -> FastArray:
         """
-        Modeled on pandas.shift.
-        Values in the array will be shifted to the right for positive, to the left for negative.
-        Spaces at either end will be filled with an invalid based on the datatype.
-        If abs(periods) >= the length of the FastArray, it will return a FastArray full of invalid
-        will be returned.
+        Return a shifted `FastArray`. Spaces at either end (from shifting) are filled with invalid values based on the input array's data type.
 
         Parameters
         ----------
-        periods: int, 1
-             number of elements to shift right (if positive) or left (if negative), defaults to 1
-        invalid: None, default
-             optional invalid value to fill
+        periods: int, default 1
+            Number of element positions to shift right (if positive) or left (if negative).
 
         Returns
         -------
-        FastArray shifted right or left by number of periods
+        A shifted `FastArray`. Spaces at either end (from shifting) are filled with invalid values based on the input array's data type.
+
+        See Also
+        --------
+        FastArray.diff : Returns a `FastArray` containing the differences between adjacent input array values.
+        .Categorical.shift : Shifts values in the `.Categorical` by a specified number of periods.
 
         Examples
         --------
-        >>> arange(5).shift(2)
-        FastArray([-2147483648, -2147483648,           0,           1,            2])
+        Shift array elements one position to the right:
+
+        >>> a=rt.FA([0, 2, 4, 8, 16, 32])
+        >>> a
+        FastArray([ 0,  2,  4,  8, 16, 32])
+        >>> a.shift()
+        FastArray([-2147483648,           0,           2,           4,
+                             8,          16])
+
+        Shift array elements two positions to the left:
+
+        >>> a.shift(-2)
+        >>> FastArray([          4,           8,          16,          32,
+                   -2147483648, -2147483648])
+
+        Specify a shift value greater than the array length:
+
+        >>> a.shift(10)
+        FastArray([-2147483648, -2147483648, -2147483648, -2147483648,
+                   -2147483648, -2147483648])
         """
 
         if periods == 0:

--- a/riptable/rt_fastarray.py
+++ b/riptable/rt_fastarray.py
@@ -163,7 +163,6 @@ def _fnanmean(x, filter):
 
 @nb.njit(parallel=True)
 def _fnanvar(x, filter):
-
     abc = 0.0
     length = 0
 
@@ -213,7 +212,6 @@ def _fmean(x, filter):
 
 @nb.njit(parallel=True)
 def _fvar(x, filter):
-
     abc = 0.0
     length = 0
 
@@ -681,6 +679,7 @@ class FastArray(np.ndarray):
             callable
                 The decorator that registers `np_function` with the decorated function.
             """
+
             # @wraps(np_function)
             def decorator(func):
                 cls.HANDLED_FUNCTIONS[np_function] = func
@@ -707,6 +706,7 @@ class FastArray(np.ndarray):
             callable
                 The decorator that registers the type compatibility check for the `np_function` with the decorated function.
             """
+
             # @wraps(np_function)
             def decorator(check_type_compatibility):
                 cls.HANDLED_TYPE_COMPATIBILITY_CHECK[np_function] = check_type_compatibility
@@ -767,7 +767,6 @@ class FastArray(np.ndarray):
 
     # --------------------------------------------------------------------------
     def __new__(cls, arr, **kwargs) -> FastArray:
-
         allow_unicode = kwargs.get("unicode", False)
         try:
             del kwargs["unicode"]
@@ -1234,7 +1233,6 @@ class FastArray(np.ndarray):
             newvalue = value
 
         if newvalue is not None:
-
             # now we have a numpy array.. convert the dtype to match us
             # this should take care of invalids
             # convert first 14 common types (bool, ints, floats)
@@ -1463,6 +1461,8 @@ class FastArray(np.ndarray):
     def _fill_invalid_internal(self, shape=None, dtype=None, inplace=True, fill_val=None):
         if dtype is None:
             dtype = self.dtype
+        if isinstance(dtype, str):
+            dtype = np.dtype(dtype)
         if shape is None:
             shape = self.shape
         elif not isinstance(shape, tuple):
@@ -1480,7 +1480,7 @@ class FastArray(np.ndarray):
                 )
             if dtype != self.dtype:
                 raise ValueError(
-                    f"Inplace fill invalid cannot be different dtype than existing categorical. Got {dtype} vs. {len(self.dtype)}"
+                    f"Inplace fill invalid cannot be different dtype than existing array. Got {dtype} vs. {len(self.dtype)}"
                 )
 
             self.fill(inv)
@@ -2730,7 +2730,6 @@ class FastArray(np.ndarray):
     #############################################
 
     def _fa_filter_wrapper(self, myFunc, filter=None, dtype=None):
-
         if filter is True:
             filter = ones(len(self), dtype=bool)
         if filter is False:
@@ -2747,7 +2746,6 @@ class FastArray(np.ndarray):
         return myFunc(self, filter)
 
     def _fa_keyword_wrapper(self, filter=None, dtype=None, axis=None, keepdims=None, ddof=None, **kwargs):
-
         if self.dtype.char in "OSU":
             raise TypeError("FastArray operation applied to string or object array.")
 
@@ -4278,7 +4276,6 @@ class FastArray(np.ndarray):
         # note: when method is 'at' this is an inplace unbuffered operation
         # this can speed up routines that use heavy masked operations
         if method == "reduce" and FastArray.FasterUFunc and not toplevel_abort:
-
             # a.any() and a.all() are logical reduce operations
             # Examples
             # Look for axis:None -- otherwise ABORT
@@ -4317,10 +4314,8 @@ class FastArray(np.ndarray):
 
         # check if we can proceed to calculate a faster way
         if method == "__call__" and FastArray.FasterUFunc and not toplevel_abort:
-
             # check for binary ufunc
             if len(args) == 2 and ufunc.nout == 1:
-
                 ###########################################################################
                 ## BINARY
                 ###########################################################################

--- a/riptable/rt_groupby.py
+++ b/riptable/rt_groupby.py
@@ -352,6 +352,47 @@ class GroupBy(GroupByOps):
         """Compute count of group"""
         return self.grouping.count(keychain=self.gb_keychain, **kwargs)
 
+    # ---------------------------------------------------------------
+    def nth(self, n: int = 1):
+        """
+        Select the nth row from each group.
+
+        Parameters
+        ----------
+        n : int
+            A single nth value for the row
+
+        Examples
+        --------
+        >>> ds = rt.Dataset({'A': [1, 1, 2, 1, 2],
+        ...                  'B': [np.nan, 2, 3, 4, 5]})
+        >>> g = ds.groupby('A')
+        >>> g.nth(0)
+        *A      B
+        --   ----
+        1    nan
+        2   3.00
+        <BLANKLINE>
+        [2 rows x 2 columns] total bytes: 32.0 B
+
+        >>> g.nth(1)
+        *A      B
+        --   ----
+        1  2.00
+        2  5.00
+        <BLANKLINE>
+        [2 rows x 2 columns] total bytes: 32.0 B
+
+        >>> g.nth(-1)
+        *A      B
+        --   ----
+        1  4.00
+        2  5.00
+        <BLANKLINE>
+        [2 rows x 2 columns] total bytes: 32.0 B
+        """
+        return super()._nth(n=n)
+
     ## ------------------------------------------------------------
     def __getattr__(self, name):
         """

--- a/riptable/test_tooling_integration/ipykernel_integration_test.py
+++ b/riptable/test_tooling_integration/ipykernel_integration_test.py
@@ -3,6 +3,8 @@ from textwrap import dedent
 from typing import List, Set, Tuple
 
 import pytest
+
+pytest.importorskip("ipykernel")
 from ipykernel.tests.utils import TIMEOUT, execute, kernel, wait_for_idle
 
 from riptable import (  # not unused; needed for evaluated code below

--- a/riptable/test_tooling_integration/ipython_compatibility_test.py
+++ b/riptable/test_tooling_integration/ipython_compatibility_test.py
@@ -8,6 +8,8 @@ import textwrap
 import unittest
 
 import pytest
+
+pytest.importorskip("IPython")
 from IPython import get_ipython
 from IPython.core import completer
 from IPython.core.completer import (

--- a/riptable/test_tooling_integration/ipython_integration_test.py
+++ b/riptable/test_tooling_integration/ipython_integration_test.py
@@ -4,6 +4,8 @@ from enum import IntEnum
 from typing import List, Union
 
 import pytest
+
+pytest.importorskip("IPython")
 from IPython import get_ipython
 from IPython.core.completer import provisionalcompleter
 from IPython.terminal import ptutils

--- a/riptable/tests/test_accum2.py
+++ b/riptable/tests/test_accum2.py
@@ -644,6 +644,11 @@ class AccumTable_Test(unittest.TestCase):
             decimal=2,
         )
 
+    def test_count_uniques(self):
+        accum = rt.Accum2([1, 1, 2, 2], ["A", "B", "C", "A"])
+        with pytest.raises(NotImplementedError):
+            accum.count_uniques(rt.arange(4))
+
 
 if __name__ == "__main__":
     tester = unittest.main()

--- a/riptable/tests/test_categorical_dtype.py
+++ b/riptable/tests/test_categorical_dtype.py
@@ -124,9 +124,10 @@ class TestCategoricalDtype:
         c = Categorical(str_fa)
         assert c._fa.dtype == np.int8
 
-        pdc._codes = pdc._codes.astype(np.int32)
-        c = Categorical(pdc)
-        assert c._fa.dtype == np.int8
+        # This breaks Pandas-2.0 (_codes is not writable), and seems an odd test to perform.
+        # pdc._codes = pdc._codes.astype(np.int32)
+        # c = Categorical(pdc)
+        # assert c._fa.dtype == np.int8
 
         c = Categorical(pdc, dtype=np.int64)
         assert c._fa.dtype == np.int64

--- a/riptable/tests/test_cut.py
+++ b/riptable/tests/test_cut.py
@@ -1,8 +1,34 @@
 import unittest
+import pytest
 
 import numpy as np
 
-from riptable import FA, Categorical, FastArray, arange, cut, qcut
+from riptable import FA, Categorical, FastArray, arange, cut, qcut, unique
+
+from riptable.testing.array_assert import assert_categorical_equal
+
+
+@pytest.mark.parametrize(
+    "kwargs, msg",
+    [
+        ({"duplicates": "drop"}, None),
+        ({}, "Bin edges must be unique"),
+        ({"duplicates": "raise"}, "Bin edges must be unique"),
+        ({"duplicates": "foo"}, "invalid value for 'duplicates' parameter"),
+    ],
+)
+def test_cut_duplicates_bin(kwargs, msg):
+    bins = FA([0, 2, 4, 6, 10, 10])
+    values = FA([1, 3, 5, 7, 9])
+    assert bins.duplicated().any(), "For this test, bins should have duplicates."
+
+    if msg is not None:
+        with pytest.raises(ValueError, match=msg):
+            cut(values, bins, **kwargs)
+    else:
+        result = cut(values, bins, **kwargs)
+        expected = cut(values, unique(bins))
+        assert_categorical_equal(result, expected)
 
 
 class Cut_Test(unittest.TestCase):

--- a/riptable/tests/test_datetime.py
+++ b/riptable/tests/test_datetime.py
@@ -2375,7 +2375,8 @@ class DateTime_Test(unittest.TestCase):
         pdt = pd.DatetimeIndex(dtn._fa)
         self.assertTrue(bool(np.all(dtn._fa == pdt.values.view(np.int64))))
 
-        df = pd.DataFrame({"pdt": pdt})
+        # Add dummy to avoid empty DataFrame errors in pandas-2.0
+        df = pd.DataFrame({"pdt": pdt, "dummy": 1})
         df = df.set_index("pdt")
 
         rule = "1H"

--- a/riptable/tests/test_fastarray.py
+++ b/riptable/tests/test_fastarray.py
@@ -1590,6 +1590,44 @@ class FastArray_Test(unittest.TestCase):
         filtered_cat = cat.filter([True, True, False, False, True, False])
         assert_array_or_cat_equal(cat.categories(), filtered_cat.categories())
 
+    def test_fill_internal(self):
+        int_fa = rt.FA([1, 2, 3])
+        float_fa = rt.FA([1.0, 2, 3])
+
+        int_inv = INVALID_DICT[int_fa.dtype.num]
+        float_inv = INVALID_DICT[float_fa.dtype.num]
+
+        # Basic test
+        int_result = int_fa.fill_invalid(inplace=False)
+        int_expected = rt.FA([int_inv, int_inv, int_inv])
+        assert_array_equal(int_expected, int_result)
+        assert int_expected.dtype == int_result.dtype
+
+        # Inplace=True
+        inplace_fa = rt.FA([1, 2, 3])
+        inplace_fa.fill_invalid()
+        inplace_expected = rt.FA([int_inv, int_inv, int_inv])
+        assert_array_equal(inplace_expected, inplace_fa)
+        assert inplace_expected.dtype == inplace_fa.dtype
+
+        # Specific dtype
+        float_result = int_fa.fill_invalid(inplace=False, dtype=np.dtype("float"))
+        float_expected = rt.FA([float_inv, float_inv, float_inv])
+        assert_array_equal(float_expected, float_result)
+        assert float_expected.dtype == float_result.dtype
+
+        # Specific dtype as string
+        float_result = int_fa.fill_invalid(inplace=False, dtype="float")
+        float_expected = rt.FA([float_inv, float_inv, float_inv])
+        assert_array_equal(float_expected, float_result)
+        assert float_expected.dtype == float_result.dtype
+
+        # Different shape
+        int_result = int_fa.fill_invalid(inplace=False, shape=2)
+        int_expected = rt.FA([int_inv, int_inv])
+        assert_array_equal(int_expected, int_result)
+        assert int_expected.dtype == int_result.dtype
+
 
 # TODO: Extend the tests in the TestFastArrayNanmax / TestFastArrayNanmin classes below to cover the following cases:
 #   * non-array inputs (e.g. a list or set or scalar)

--- a/riptable/tests/test_str.py
+++ b/riptable/tests/test_str.py
@@ -489,6 +489,8 @@ class TestFAString:
             (-1,),
             (-3, -1),
             (-1, 1),
+            (None, 3),
+            (None, None),
         ],
     )
 
@@ -513,18 +515,23 @@ class TestFAString:
         # check categories are unique
         assert len(set(result.category_array)) == len(result.category_array)
 
+    def test_substr_stop_is_None(self):
+        result = FAString(SYMBOLS).str.substr(3, None)
+        expected = rt.FastArray([s[:3] for s in SYMBOLS])
+        assert_array_equal(result, expected)
+
     @parametrize(
-        "start, stop, expected",
+        "start_stop, expected",
         [
-            (0, [1, 2, 3, 2, 3], ["A", "AM", "FB", "GO", "IBM"]),
-            ([1, 1, 1, 1, 1], [1, 2, 3, 2, 3], ["", "M", "B", "O", "BM"]),
-            ([1, 2, 3, 2, 3], None, ["A", "AM", "FB", "GO", "IBM"]),
-            ([0, 1, 1, 0, 1], [3, 10, 2, -1, -2], ["AAP", "MZN", "B", "GOO", ""]),
-            ([1, 1, 1, 1, 1], [1, 1, 1, 1, 1], ["", "", "", "", ""]),
+            ((0, [1, 2, 3, 2, 3]), ["A", "AM", "FB", "GO", "IBM"]),
+            (([1, 1, 1, 1, 1], [1, 2, 3, 2, 3]), ["", "M", "B", "O", "BM"]),
+            (([1, 2, 3, 2, 3],), ["A", "AM", "FB", "GO", "IBM"]),
+            (([0, 1, 1, 0, 1], [3, 10, 2, -1, -2]), ["AAP", "MZN", "B", "GOO", ""]),
+            (([1, 1, 1, 1, 1], [1, 1, 1, 1, 1]), ["", "", "", "", ""]),
         ],
     )
-    def test_substr_array_bounds(self, start, stop, expected):
-        result = FAString(SYMBOLS).substr(start, stop)
+    def test_substr_array_bounds(self, start_stop, expected):
+        result = FAString(SYMBOLS).substr(*start_stop)
         assert_array_equal(rt.FastArray(expected), result)
 
     @substr_test_cases
@@ -542,6 +549,11 @@ class TestFAString:
         indexer = [0, 1, 0, 1, 0]
         expected = rt.FastArray([s[i] for s, i in zip(SYMBOLS, indexer)])
         result = FAString(SYMBOLS).substr[indexer]
+        assert_array_equal(expected, result)
+
+    def test_substr_getitem_None_stop(self):
+        expected = rt.FastArray([s[-2:] for s in SYMBOLS])
+        result = FAString(SYMBOLS).substr[-2:]
         assert_array_equal(expected, result)
 
     def test_substr_char_stop(self):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     "numpy >=1.22",
     "pandas >=1.0,<3.0",
     "python-dateutil",
-    "riptide_cpp >=1.12.1,<2",
+    "riptide_cpp >=1.12.2,<2",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@ package_name = "riptable"
 
 install_requires = [
     "ansi2html >=1.5.2",
-    "ipykernel",
     "numba >=0.56.2",
     "numpy >=1.22",
-    "pandas >=0.24,<2.0",
+    "pandas >=1.0,<3.0",
     "python-dateutil",
     "riptide_cpp >=1.12.1,<2",
 ]


### PR DESCRIPTION
### Changes:
* Tutorial: Add more advanced Categorical instantiation example
* Fixes FAString.substr()
* Changes to count_uniques fixing regression issue
* Code change: Add 'duplicates' param to rt.cut()
* Add support for Pandas-2.0
* Fix regression with mask_xxx() involving scalars.
* Remove ipykernel runtime requirement
* Docstring: Cat.category_array
* Docstring: cat._fa
* Avoid IPython-8.13 on Python-3.8
* In GroupByOps.count_uniques, correctly handle the cases when filter excludes...
* Add cat shift filter
* Code update for fa.fill_internal_invalid
* Make GroupByOps.nth() abstract
* Add 'columns' kwarg to rt.Dataset.trim method
* Docstring: fa.duplicated
* Docstring: fa_copy
* Docstring: fa_between
* Add black format check (EX95)
* Pin to riptide_cpp-1.12.2
* Docstring: fa.nunique
* Docstring: fa.shift
* Docstring: rt.cut()
* Docstring: fa_sample
* Docstring: fa._np